### PR TITLE
Bugfix/shared layers

### DIFF
--- a/census_example.ipynb
+++ b/census_example.ipynb
@@ -19,7 +19,10 @@
     "\n",
     "import os\n",
     "import wget\n",
-    "from pathlib import Path"
+    "from pathlib import Path\n",
+    "\n",
+    "from matplotlib import pyplot as plt\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -185,6 +188,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot losses\n",
+    "plt.plot(clf.history['train']['loss'])\n",
+    "plt.plot(clf.history['valid']['loss'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot auc\n",
+    "plt.plot([-x for x in clf.history['train']['metric']])\n",
+    "plt.plot([-x for x in clf.history['valid']['metric']])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -253,16 +278,6 @@
    "outputs": [],
    "source": [
     "explain_matrix, masks = clf.explain(X_test)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from matplotlib import pyplot as plt\n",
-    "%matplotlib inline"
    ]
   },
   {

--- a/forest_example.ipynb
+++ b/forest_example.ipynb
@@ -381,11 +381,11 @@
    "outputs": [],
    "source": [
     "preds_valid = np.array(clf_xgb.predict_proba(X_valid, ))\n",
-    "valid_acc = accuracy_score(y_pred=np.argmax(preds_valid, axis=1), y_true=y_valid)\n",
+    "valid_acc = accuracy_score(y_pred=np.argmax(preds_valid, axis=1) + 1, y_true=y_valid)\n",
     "print(valid_acc)\n",
     "\n",
     "preds_test = np.array(clf_xgb.predict_proba(X_test))\n",
-    "test_acc = accuracy_score(y_pred=np.argmax(preds_test, axis=1), y_true=y_test)\n",
+    "test_acc = accuracy_score(y_pred=np.argmax(preds_test, axis=1) + 1, y_true=y_test)\n",
     "print(test_acc)"
    ]
   },

--- a/forest_example.ipynb
+++ b/forest_example.ipynb
@@ -186,7 +186,7 @@
    "outputs": [],
    "source": [
     "clf = TabNetClassifier(\n",
-    "    n_d=32, n_a=32, n_steps=5,\n",
+    "    n_d=64, n_a=64, n_steps=5,\n",
     "    lr=0.02,\n",
     "    gamma=1.5, n_independent=2, n_shared=2,\n",
     "    cat_idxs=cat_idxs,\n",

--- a/forest_example.ipynb
+++ b/forest_example.ipynb
@@ -21,7 +21,10 @@
     "import wget\n",
     "from pathlib import Path\n",
     "import shutil\n",
-    "import gzip\n"
+    "import gzip\n",
+    "\n",
+    "from matplotlib import pyplot as plt\n",
+    "%matplotlib inline"
    ]
   },
   {
@@ -240,6 +243,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot losses\n",
+    "plt.plot(clf.history['train']['loss'])\n",
+    "plt.plot(clf.history['valid']['loss'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot accuracies\n",
+    "plt.plot([-x for x in clf.history['train']['metric']])\n",
+    "plt.plot([-x for x in clf.history['valid']['metric']])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -318,9 +343,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matplotlib import pyplot as plt\n",
-    "%matplotlib inline\n",
-    "\n",
     "fig, axs = plt.subplots(1, 5, figsize=(20,20))\n",
     "\n",
     "for i in range(5):\n",

--- a/pytorch_tabnet/tab_model.py
+++ b/pytorch_tabnet/tab_model.py
@@ -200,6 +200,11 @@ class TabModel(object):
                 print(f"Early stopping occured at epoch {self.epoch}")
             print(f"Training done in {total_time:.3f} seconds.")
             print('---------------------------------------')
+
+        self.history = {"train": {"loss": losses_train,
+                                  "metric": metrics_train},
+                        "valid": {"loss": losses_valid,
+                                  "metric": metrics_valid}}
         # load best models post training
         self.load_best_model()
 

--- a/pytorch_tabnet/tab_model.py
+++ b/pytorch_tabnet/tab_model.py
@@ -502,7 +502,6 @@ class TabNetClassifier(TabModel):
 
         if self.scheduler is not None:
             self.scheduler.step()
-            print("Current learning rate: ", self.optimizer.param_groups[-1]["lr"])
         return epoch_metrics
 
     def train_batch(self, data, targets):

--- a/pytorch_tabnet/tab_model.py
+++ b/pytorch_tabnet/tab_model.py
@@ -10,6 +10,7 @@ from pytorch_tabnet.utils import (PredictDataset,
                                   create_dataloaders,
                                   create_explain_matrix)
 from torch.utils.data import DataLoader
+from datetime import datetime
 
 
 class TabModel(object):
@@ -106,6 +107,10 @@ class TabModel(object):
             virtual_batch_size : int
                 Batch size for Ghost Batch Normalization (virtual_batch_size < batch_size)
         """
+        # update model name
+        now = datetime.now()
+        dt_string = now.strftime("_%d-%m-%Y_%H:%M:%S")
+        self.model_name += dt_string
 
         self.update_fit_params(X_train, y_train, X_valid, y_valid, loss_fn,
                                weights, max_epochs, patience, batch_size, virtual_batch_size)

--- a/pytorch_tabnet/tab_network.py
+++ b/pytorch_tabnet/tab_network.py
@@ -127,15 +127,16 @@ class TabNet(torch.nn.Module):
         self.initial_bn = BatchNorm1d(self.post_embed_dim, momentum=0.01)
 
         if self.n_shared > 0:
-            shared_feat_transform = GLU_Block(self.post_embed_dim,
-                                              n_d+n_a,
-                                              n_glu=self.n_shared,
-                                              virtual_batch_size=self.virtual_batch_size,
-                                              first=True,
-                                              momentum=momentum,
-                                              device=self.device)
+            shared_feat_transform = torch.nn.ModuleList()
+            for i in range(self.n_shared):
+                if i == 0:
+                    shared_feat_transform.append(Linear(self.post_embed_dim, 2*(n_d + n_a), bias=False))
+                else:
+                    shared_feat_transform.append(Linear(n_d + n_a, 2*(n_d + n_a), bias=False))
+
         else:
             shared_feat_transform = None
+
         self.initial_splitter = FeatTransformer(self.post_embed_dim, n_d+n_a, shared_feat_transform,
                                                 n_glu=self.n_independent,
                                                 virtual_batch_size=self.virtual_batch_size,
@@ -244,7 +245,7 @@ class AttentiveTransformer(torch.nn.Module):
 
 
 class FeatTransformer(torch.nn.Module):
-    def __init__(self, input_dim, output_dim, shared_blocks, n_glu,
+    def __init__(self, input_dim, output_dim, shared_layers, n_glu,
                  virtual_batch_size=128, momentum=0.02, device='cpu'):
         super(FeatTransformer, self).__init__()
         """
@@ -256,19 +257,13 @@ class FeatTransformer(torch.nn.Module):
             Input size
         - output_dim : int
             Outpu_size
-        - shared_blocks : torch.nn.Module
+        - shared_blocks : torch.nn.ModuleList
             The shared block that should be common to every step
         - momentum : float
             Float value between 0 and 1 which will be used for momentum in batch norm
         """
 
-        self.shared = shared_blocks
-        if self.shared is not None:
-            for l in self.shared.glu_layers:
-                l.bn = GBN(2*output_dim, virtual_batch_size=virtual_batch_size,
-                           momentum=momentum, device=device)
-
-        if self.shared is None:
+        if shared_layers is None:
             self.specifics = GLU_Block(input_dim, output_dim,
                                        n_glu=n_glu,
                                        first=True,
@@ -276,6 +271,13 @@ class FeatTransformer(torch.nn.Module):
                                        momentum=momentum,
                                        device=device)
         else:
+            self.shared = GLU_Block(input_dim, output_dim,
+                                    n_glu=n_glu,
+                                    first=True,
+                                    shared_layers=shared_layers,
+                                    virtual_batch_size=virtual_batch_size,
+                                    momentum=momentum,
+                                    device=device)
             self.specifics = GLU_Block(output_dim, output_dim,
                                        n_glu=n_glu,
                                        virtual_batch_size=virtual_batch_size,
@@ -284,7 +286,11 @@ class FeatTransformer(torch.nn.Module):
 
     def forward(self, x):
         if self.shared is not None:
+            # print('-------before----------')
+            # print(self.shared.glu_layers[0].bn.bn.running_mean)
             x = self.shared(x)
+            # print('-------after-----------')
+            # print(self.shared.glu_layers[0].bn.bn.running_mean)
         x = self.specifics(x)
         return x
 
@@ -293,24 +299,41 @@ class GLU_Block(torch.nn.Module):
     """
         Independant GLU block, specific to each step
     """
-    def __init__(self, input_dim, output_dim, n_glu=2, first=False,
+    def __init__(self, input_dim, output_dim, n_glu=2, first=False, shared_layers=None,
                  virtual_batch_size=128, momentum=0.02, device='cpu'):
         super(GLU_Block, self).__init__()
         self.first = first
+        self.shared_layers = shared_layers
         self.n_glu = n_glu
         self.glu_layers = torch.nn.ModuleList()
         self.scale = torch.sqrt(torch.FloatTensor([0.5]).to(device))
-        for glu_id in range(self.n_glu):
-            if glu_id == 0:
-                self.glu_layers.append(GLU_Layer(input_dim, output_dim,
-                                                 virtual_batch_size=virtual_batch_size,
-                                                 momentum=momentum,
-                                                 device=device))
-            else:
-                self.glu_layers.append(GLU_Layer(output_dim, output_dim,
-                                                 virtual_batch_size=virtual_batch_size,
-                                                 momentum=momentum,
-                                                 device=device))
+
+        if shared_layers:
+            for glu_id in range(self.n_glu):
+                if glu_id == 0:
+                    self.glu_layers.append(GLU_Layer(input_dim, output_dim,
+                                                     fc=shared_layers[glu_id],
+                                                     virtual_batch_size=virtual_batch_size,
+                                                     momentum=momentum,
+                                                     device=device))
+                else:
+                    self.glu_layers.append(GLU_Layer(output_dim, output_dim,
+                                                     fc=shared_layers[glu_id],
+                                                     virtual_batch_size=virtual_batch_size,
+                                                     momentum=momentum,
+                                                     device=device))
+        else:
+            for glu_id in range(self.n_glu):
+                if glu_id == 0:
+                    self.glu_layers.append(GLU_Layer(input_dim, output_dim,
+                                                    virtual_batch_size=virtual_batch_size,
+                                                    momentum=momentum,
+                                                    device=device))
+                else:
+                    self.glu_layers.append(GLU_Layer(output_dim, output_dim,
+                                                    virtual_batch_size=virtual_batch_size,
+                                                    momentum=momentum,
+                                                    device=device))
 
     def forward(self, x):
         if self.first:  # the first layer of the block has no scale multiplication
@@ -326,12 +349,15 @@ class GLU_Block(torch.nn.Module):
 
 
 class GLU_Layer(torch.nn.Module):
-    def __init__(self, input_dim, output_dim,
+    def __init__(self, input_dim, output_dim, fc=None,
                  virtual_batch_size=128, momentum=0.02, device='cpu'):
         super(GLU_Layer, self).__init__()
 
         self.output_dim = output_dim
-        self.fc = Linear(input_dim, 2*output_dim, bias=False)
+        if fc:
+            self.fc = fc
+        else:
+            self.fc = Linear(input_dim, 2*output_dim, bias=False)
         initialize_glu(self.fc, input_dim, 2*output_dim)
 
         self.bn = GBN(2*output_dim, virtual_batch_size=virtual_batch_size,

--- a/pytorch_tabnet/tab_network.py
+++ b/pytorch_tabnet/tab_network.py
@@ -130,7 +130,9 @@ class TabNet(torch.nn.Module):
             shared_feat_transform = torch.nn.ModuleList()
             for i in range(self.n_shared):
                 if i == 0:
-                    shared_feat_transform.append(Linear(self.post_embed_dim, 2*(n_d + n_a), bias=False))
+                    shared_feat_transform.append(Linear(self.post_embed_dim,
+                                                        2*(n_d + n_a),
+                                                        bias=False))
                 else:
                     shared_feat_transform.append(Linear(n_d + n_a, 2*(n_d + n_a), bias=False))
 


### PR DESCRIPTION
Since `deepcopy` was removed in order to share the weights between layers, we noticed that the batch normalizations had also been shared, which should not be the case.

Here, we make sure that batchnorms are independent and that layer weights are shared.