### PR TITLE
fastai compatibility

### DIFF
--- a/pytorch_tabnet/tab_network.py
+++ b/pytorch_tabnet/tab_network.py
@@ -3,7 +3,6 @@ from torch.nn import Linear, BatchNorm1d, ReLU
 import numpy as np
 from pytorch_tabnet import sparsemax
 
-
 def initialize_non_glu(module, input_dim, output_dim):
     gain_value = np.sqrt((input_dim+output_dim)/np.sqrt(4*input_dim))
     torch.nn.init.xavier_normal_(module.weight, gain=gain_value)
@@ -23,23 +22,132 @@ class GBN(torch.nn.Module):
         Ghost Batch Normalization
         https://arxiv.org/abs/1705.08741
     """
-    def __init__(self, input_dim, virtual_batch_size=128, momentum=0.01, device='cpu'):
+    def __init__(self, input_dim, virtual_batch_size=128, momentum=0.01):
         super(GBN, self).__init__()
 
         self.input_dim = input_dim
         self.virtual_batch_size = virtual_batch_size
         self.bn = BatchNorm1d(self.input_dim, momentum=momentum)
-        self.device = device
 
     def forward(self, x):
         chunks = x.chunk(x.shape[0] // self.virtual_batch_size +
                          ((x.shape[0] % self.virtual_batch_size) > 0))
-        res = torch.Tensor([]).to(self.device)
+        res = torch.Tensor([]).to(x.device)
         for x_ in chunks:
             y = self.bn(x_)
             res = torch.cat([res, y], dim=0)
 
         return res
+
+class DryTabNet(torch.nn.Module):
+    def __init__(self, input_dim, output_dim, 
+                 n_d=8, n_a=8,
+                 n_steps=3, gamma=1.3, 
+                 n_independent=2, n_shared=2, epsilon=1e-15,
+                 virtual_batch_size=128, momentum=0.02):
+        """
+        Defines the essence of TabNet network
+
+        Parameters
+        ----------
+        - input_dim : int
+            Number of features
+        - output_dim : int
+            Dimension of network output
+            examples : one for regression, 2 for binary classification etc...
+        - n_d : int
+            Dimension of the prediction  layer (usually between 4 and 64)
+        - n_a : int
+            Dimension of the attention  layer (usually between 4 and 64)
+        - n_steps: int
+            Number of sucessive steps in the newtork (usually betwenn 3 and 10)
+        - gamma : float
+            Float above 1, scaling factor for attention updates (usually betwenn 1.0 to 2.0)
+        - momentum : float
+            Float value between 0 and 1 which will be used for momentum in all batch norm
+        - n_independent : int
+            Number of independent GLU layer in each GLU block (default 2)
+        - n_shared : int
+            Number of independent GLU layer in each GLU block (default 2)
+        - epsilon: float
+            Avoid log(0), this should be kept very low
+        """
+        super(DryTabNet, self).__init__()
+        self.input_dim = input_dim
+        self.output_dim = output_dim
+        self.n_d = n_d
+        self.n_a = n_a
+        self.n_steps = n_steps
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self.n_independent = n_independent
+        self.n_shared = n_shared
+        self.virtual_batch_size = virtual_batch_size
+        
+        if self.n_shared > 0:
+            shared_feat_transform = torch.nn.ModuleList()
+            for i in range(self.n_shared):
+                if i == 0:
+                    shared_feat_transform.append(Linear(self.input_dim,
+                                                        2*(n_d + n_a),
+                                                        bias=False))
+                else:
+                    shared_feat_transform.append(Linear(n_d + n_a, 2*(n_d + n_a), bias=False))
+
+        else:
+            shared_feat_transform = None
+
+        self.initial_splitter = FeatTransformer(self.input_dim, n_d+n_a, shared_feat_transform,
+                                                n_glu=self.n_independent,
+                                                virtual_batch_size=self.virtual_batch_size,
+                                                momentum=momentum)
+
+        self.feat_transformers = torch.nn.ModuleList()
+        self.att_transformers = torch.nn.ModuleList()
+
+        for step in range(n_steps):
+            transformer = FeatTransformer(self.input_dim, n_d+n_a, shared_feat_transform,
+                                          n_glu=self.n_independent,
+                                          virtual_batch_size=self.virtual_batch_size,
+                                          momentum=momentum)
+            attention = AttentiveTransformer(n_a, self.input_dim,
+                                             virtual_batch_size=self.virtual_batch_size,
+                                             momentum=momentum)
+            self.feat_transformers.append(transformer)
+            self.att_transformers.append(attention)
+
+        self.final_mapping = Linear(n_d, output_dim, bias=False)
+        initialize_non_glu(self.final_mapping, n_d, output_dim)
+
+    def forward(self, x):
+        res = 0
+
+        prior = torch.ones(x.shape).to(x.device)
+        M_explain = torch.zeros(x.shape).to(x.device)
+        M_loss = 0
+        att = self.initial_splitter(x)[:, self.n_d:]
+        masks = {}
+
+        for step in range(self.n_steps):
+            M = self.att_transformers[step](prior, att)
+            masks[step] = M
+            M_loss += torch.mean(torch.sum(torch.mul(M, torch.log(M+self.epsilon)),
+                                           dim=1)) / (self.n_steps)
+            # update prior
+            prior = torch.mul(self.gamma - M, prior)
+            # output
+            masked_x = torch.mul(M, x)
+            out = self.feat_transformers[step](masked_x)
+            d = ReLU()(out[:, :self.n_d])
+            res = torch.add(res, d)
+            # explain
+            step_importance = torch.sum(d, dim=1)
+            M_explain += torch.mul(M, step_importance.unsqueeze(dim=1))
+            # update attention
+            att = out[:, self.n_d:]
+
+        res = self.final_mapping(res)
+        return res, M_loss, M_explain, masks
 
 
 class TabNet(torch.nn.Module):
@@ -83,6 +191,10 @@ class TabNet(torch.nn.Module):
             Avoid log(0), this should be kept very low
         """
         super(TabNet, self).__init__()
+        self.cat_idxs = cat_idxs or []
+        self.cat_dims = cat_dims or []
+        self.cat_emb_dim = cat_emb_dim
+        
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.n_d = n_d
@@ -92,18 +204,7 @@ class TabNet(torch.nn.Module):
         self.epsilon = epsilon
         self.n_independent = n_independent
         self.n_shared = n_shared
-        self.cat_idxs = cat_idxs or []
-        self.cat_dims = cat_dims or []
-        self.cat_emb_dim = cat_emb_dim
         self.virtual_batch_size = virtual_batch_size
-
-        # Defining device
-        if device_name == 'auto':
-            if torch.cuda.is_available():
-                device_name = 'cuda'
-            else:
-                device_name = 'cpu'
-        self.device = torch.device(device_name)
 
         if type(cat_emb_dim) == int:
             self.cat_emb_dims = [cat_emb_dim]*len(self.cat_idxs)
@@ -124,47 +225,17 @@ class TabNet(torch.nn.Module):
         else:
             self.post_embed_dim = self.input_dim + np.sum(cat_emb_dim) - len(cat_emb_dim)
         self.post_embed_dim = np.int(self.post_embed_dim)
+        self.tabnet = DryTabNet(self.post_embed_dim, output_dim, n_d, n_a, n_steps, gamma, n_independent, n_shared, epsilon, virtual_batch_size, momentum)
         self.initial_bn = BatchNorm1d(self.post_embed_dim, momentum=0.01)
 
-        if self.n_shared > 0:
-            shared_feat_transform = torch.nn.ModuleList()
-            for i in range(self.n_shared):
-                if i == 0:
-                    shared_feat_transform.append(Linear(self.post_embed_dim,
-                                                        2*(n_d + n_a),
-                                                        bias=False))
-                else:
-                    shared_feat_transform.append(Linear(n_d + n_a, 2*(n_d + n_a), bias=False))
-
-        else:
-            shared_feat_transform = None
-
-        self.initial_splitter = FeatTransformer(self.post_embed_dim, n_d+n_a, shared_feat_transform,
-                                                n_glu=self.n_independent,
-                                                virtual_batch_size=self.virtual_batch_size,
-                                                momentum=momentum,
-                                                device=self.device)
-
-        # self.shared_feat_transformers = torch.nn.ModuleList()
-        self.feat_transformers = torch.nn.ModuleList()
-        self.att_transformers = torch.nn.ModuleList()
-
-        for step in range(n_steps):
-            transformer = FeatTransformer(self.post_embed_dim, n_d+n_a, shared_feat_transform,
-                                          n_glu=self.n_independent,
-                                          virtual_batch_size=self.virtual_batch_size,
-                                          momentum=momentum,
-                                          device=self.device)
-            attention = AttentiveTransformer(n_a, self.post_embed_dim,
-                                             virtual_batch_size=self.virtual_batch_size,
-                                             momentum=momentum,
-                                             device=self.device)
-            self.feat_transformers.append(transformer)
-            self.att_transformers.append(attention)
-
-        self.soft_max = torch.nn.Softmax(dim=1)
-        self.final_mapping = Linear(n_d, output_dim, bias=False)
-        initialize_non_glu(self.final_mapping, n_d, output_dim)
+        # Defining device
+        if device_name == 'auto':
+            if torch.cuda.is_available():
+                device_name = 'cuda'
+            else:
+                device_name = 'cpu'
+        self.device = torch.device(device_name)
+        self.to(self.device)
 
     def apply_embeddings(self, x):
         """Apply embdeddings to raw inputs"""
@@ -181,40 +252,12 @@ class TabNet(torch.nn.Module):
         return post_embeddings
 
     def forward(self, x):
-        res = 0
         x = self.apply_embeddings(x)
         x = self.initial_bn(x)
-
-        prior = torch.ones(x.shape).to(self.device)
-        M_explain = torch.zeros(x.shape).to(self.device)
-        M_loss = 0
-        att = self.initial_splitter(x)[:, self.n_d:]
-        masks = {}
-
-        for step in range(self.n_steps):
-            M = self.att_transformers[step](prior, att)
-            masks[step] = M
-            M_loss += torch.mean(torch.sum(torch.mul(M, torch.log(M+self.epsilon)),
-                                           dim=1)) / (self.n_steps)
-            # update prior
-            prior = torch.mul(self.gamma - M, prior)
-            # output
-            masked_x = torch.mul(M, x)
-            out = self.feat_transformers[step](masked_x)
-            d = ReLU()(out[:, :self.n_d])
-            res = torch.add(res, d)
-            # explain
-            step_importance = torch.sum(d, dim=1)
-            M_explain += torch.mul(M, step_importance.unsqueeze(dim=1))
-            # update attention
-            att = out[:, self.n_d:]
-
-        res = self.final_mapping(res)
-        return res, M_loss, M_explain, masks
-
+        return self.tabnet(x)
 
 class AttentiveTransformer(torch.nn.Module):
-    def __init__(self, input_dim, output_dim, virtual_batch_size=128, momentum=0.02, device='cpu'):
+    def __init__(self, input_dim, output_dim, virtual_batch_size=128, momentum=0.02):
         """
         Initialize an attention transformer.
 
@@ -231,7 +274,7 @@ class AttentiveTransformer(torch.nn.Module):
         self.fc = Linear(input_dim, output_dim, bias=False)
         initialize_non_glu(self.fc, input_dim, output_dim)
         self.bn = GBN(output_dim, virtual_batch_size=virtual_batch_size,
-                      momentum=momentum, device=device)
+                      momentum=momentum)
 
         # Sparsemax
         self.sp_max = sparsemax.Sparsemax(dim=-1)
@@ -248,7 +291,7 @@ class AttentiveTransformer(torch.nn.Module):
 
 class FeatTransformer(torch.nn.Module):
     def __init__(self, input_dim, output_dim, shared_layers, n_glu,
-                 virtual_batch_size=128, momentum=0.02, device='cpu'):
+                 virtual_batch_size=128, momentum=0.02):
         super(FeatTransformer, self).__init__()
         """
         Initialize a feature transformer.
@@ -268,8 +311,7 @@ class FeatTransformer(torch.nn.Module):
         params = {
             'n_glu': n_glu,
             'virtual_batch_size': virtual_batch_size,
-            'momentum': momentum,
-            'device': device
+            'momentum': momentum
         }
 
         if shared_layers is None:
@@ -296,18 +338,17 @@ class GLU_Block(torch.nn.Module):
         Independant GLU block, specific to each step
     """
     def __init__(self, input_dim, output_dim, n_glu=2, first=False, shared_layers=None,
-                 virtual_batch_size=128, momentum=0.02, device='cpu'):
+                 virtual_batch_size=128, momentum=0.02):
         super(GLU_Block, self).__init__()
         self.first = first
         self.shared_layers = shared_layers
         self.n_glu = n_glu
         self.glu_layers = torch.nn.ModuleList()
-        self.scale = torch.sqrt(torch.FloatTensor([0.5]).to(device))
+        
 
         params = {
             'virtual_batch_size': virtual_batch_size,
-            'momentum': momentum,
-            'device': device
+            'momentum': momentum
         }
 
         fc = shared_layers[0] if shared_layers else None
@@ -321,6 +362,7 @@ class GLU_Block(torch.nn.Module):
                                              **params))
 
     def forward(self, x):
+        scale = torch.sqrt(torch.FloatTensor([0.5]).to(x.device))
         if self.first:  # the first layer of the block has no scale multiplication
             x = self.glu_layers[0](x)
             layers_left = range(1, self.n_glu)
@@ -329,13 +371,13 @@ class GLU_Block(torch.nn.Module):
 
         for glu_id in layers_left:
             x = torch.add(x, self.glu_layers[glu_id](x))
-            x = x*self.scale
+            x = x*scale
         return x
 
 
 class GLU_Layer(torch.nn.Module):
     def __init__(self, input_dim, output_dim, fc=None,
-                 virtual_batch_size=128, momentum=0.02, device='cpu'):
+                 virtual_batch_size=128, momentum=0.02):
         super(GLU_Layer, self).__init__()
 
         self.output_dim = output_dim
@@ -346,7 +388,7 @@ class GLU_Layer(torch.nn.Module):
         initialize_glu(self.fc, input_dim, 2*output_dim)
 
         self.bn = GBN(2*output_dim, virtual_batch_size=virtual_batch_size,
-                      momentum=momentum, device=device)
+                      momentum=momentum)
 
     def forward(self, x):
         x = self.fc(x)

--- a/pytorch_tabnet/tab_network.py
+++ b/pytorch_tabnet/tab_network.py
@@ -3,6 +3,7 @@ from torch.nn import Linear, BatchNorm1d, ReLU
 import numpy as np
 from pytorch_tabnet import sparsemax
 
+
 def initialize_non_glu(module, input_dim, output_dim):
     gain_value = np.sqrt((input_dim+output_dim)/np.sqrt(4*input_dim))
     torch.nn.init.xavier_normal_(module.weight, gain=gain_value)
@@ -22,6 +23,7 @@ class GBN(torch.nn.Module):
         Ghost Batch Normalization
         https://arxiv.org/abs/1705.08741
     """
+
     def __init__(self, input_dim, virtual_batch_size=128, momentum=0.01):
         super(GBN, self).__init__()
 
@@ -39,10 +41,11 @@ class GBN(torch.nn.Module):
 
         return res
 
+
 class DryTabNet(torch.nn.Module):
-    def __init__(self, input_dim, output_dim, 
+    def __init__(self, input_dim, output_dim,
                  n_d=8, n_a=8,
-                 n_steps=3, gamma=1.3, 
+                 n_steps=3, gamma=1.3,
                  n_independent=2, n_shared=2, epsilon=1e-15,
                  virtual_batch_size=128, momentum=0.02):
         """
@@ -83,7 +86,7 @@ class DryTabNet(torch.nn.Module):
         self.n_independent = n_independent
         self.n_shared = n_shared
         self.virtual_batch_size = virtual_batch_size
-        
+
         if self.n_shared > 0:
             shared_feat_transform = torch.nn.ModuleList()
             for i in range(self.n_shared):
@@ -194,7 +197,7 @@ class TabNet(torch.nn.Module):
         self.cat_idxs = cat_idxs or []
         self.cat_dims = cat_dims or []
         self.cat_emb_dim = cat_emb_dim
-        
+
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.n_d = n_d
@@ -225,7 +228,8 @@ class TabNet(torch.nn.Module):
         else:
             self.post_embed_dim = self.input_dim + np.sum(cat_emb_dim) - len(cat_emb_dim)
         self.post_embed_dim = np.int(self.post_embed_dim)
-        self.tabnet = DryTabNet(self.post_embed_dim, output_dim, n_d, n_a, n_steps, gamma, n_independent, n_shared, epsilon, virtual_batch_size, momentum)
+        self.tabnet = DryTabNet(self.post_embed_dim, output_dim, n_d, n_a, n_steps, gamma,
+                                n_independent, n_shared, epsilon, virtual_batch_size, momentum)
         self.initial_bn = BatchNorm1d(self.post_embed_dim, momentum=0.01)
 
         # Defining device
@@ -255,6 +259,7 @@ class TabNet(torch.nn.Module):
         x = self.apply_embeddings(x)
         x = self.initial_bn(x)
         return self.tabnet(x)
+
 
 class AttentiveTransformer(torch.nn.Module):
     def __init__(self, input_dim, output_dim, virtual_batch_size=128, momentum=0.02):
@@ -337,6 +342,7 @@ class GLU_Block(torch.nn.Module):
     """
         Independant GLU block, specific to each step
     """
+
     def __init__(self, input_dim, output_dim, n_glu=2, first=False, shared_layers=None,
                  virtual_batch_size=128, momentum=0.02):
         super(GLU_Block, self).__init__()
@@ -344,7 +350,6 @@ class GLU_Block(torch.nn.Module):
         self.shared_layers = shared_layers
         self.n_glu = n_glu
         self.glu_layers = torch.nn.ModuleList()
-        
 
         params = {
             'virtual_batch_size': virtual_batch_size,

--- a/pytorch_tabnet/tab_network.py
+++ b/pytorch_tabnet/tab_network.py
@@ -42,14 +42,14 @@ class GBN(torch.nn.Module):
         return res
 
 
-class DryTabNet(torch.nn.Module):
+class TabNetNoEmbeddings(torch.nn.Module):
     def __init__(self, input_dim, output_dim,
                  n_d=8, n_a=8,
                  n_steps=3, gamma=1.3,
                  n_independent=2, n_shared=2, epsilon=1e-15,
                  virtual_batch_size=128, momentum=0.02):
         """
-        Defines the essence of TabNet network
+        Defines main part of the TabNet network without the embedding layers.
 
         Parameters
         ----------
@@ -75,7 +75,7 @@ class DryTabNet(torch.nn.Module):
         - epsilon: float
             Avoid log(0), this should be kept very low
         """
-        super(DryTabNet, self).__init__()
+        super(TabNetNoEmbeddings, self).__init__()
         self.input_dim = input_dim
         self.output_dim = output_dim
         self.n_d = n_d
@@ -228,8 +228,9 @@ class TabNet(torch.nn.Module):
         else:
             self.post_embed_dim = self.input_dim + np.sum(cat_emb_dim) - len(cat_emb_dim)
         self.post_embed_dim = np.int(self.post_embed_dim)
-        self.tabnet = DryTabNet(self.post_embed_dim, output_dim, n_d, n_a, n_steps, gamma,
-                                n_independent, n_shared, epsilon, virtual_batch_size, momentum)
+        self.tabnet = TabNetNoEmbeddings(self.post_embed_dim, output_dim, n_d, n_a, n_steps,
+                                         gamma, n_independent, n_shared, epsilon,
+                                         virtual_batch_size, momentum)
         self.initial_bn = BatchNorm1d(self.post_embed_dim, momentum=0.01)
 
         # Defining device


### PR DESCRIPTION
1. Remove `device` from nn.Module (most)
2. Split TabNet in two classes. One for processing embeddings (framework-specific) and one for pure TabNet.