### PR TITLE
Remove duplicate documentation for `scheduler_params`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can also get comfortable with how the code works by playing with the **noteb
 
 - scheduler_params : dict
 
-    Dictionnary of parameters to apply to the scheduler_fn.
+    Dictionnary of parameters to apply to the scheduler_fn. Ex : {"gamma": 0.95, "step_size": 10}
 
 - model_name : str (default = 'DreamQuarkTabNet')
 
@@ -129,9 +129,7 @@ You can also get comfortable with how the code works by playing with the **noteb
 - saving_path : str (default = './')
 
     Path defining where to save models.
-- scheduler_params: dict
 
-    Parameters dictionnary for the scheduler_fn. Ex : {"gamma": 0.95,                    "step_size": 10}
 - verbose : int (default=1)
 
     Verbosity for notebooks plots, set to 1 to see every epoch, 0 to get None.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase.  -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`scheduler_params` is documented twice. This PR keeps the most well entries in the documentation and removes the other one.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Removes duplicates entries for the `scheduler_params` parameter of tabnet

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
Not applicable.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

**Closing issues**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
