### PR TITLE
Set feature importance tensor size according to embedding dimensions (TabNetRegressor)

### DIFF
--- a/pytorch_tabnet/tab_model.py
+++ b/pytorch_tabnet/tab_model.py
@@ -718,7 +718,7 @@ class TabNetRegressor(TabModel):
         y_preds = []
         ys = []
         total_loss = 0
-        feature_importances_ = np.zeros((self.input_dim))
+        feature_importances_ = np.zeros((self.network.post_embed_dim))
 
         for data, targets in train_loader:
             batch_outs = self.train_batch(data, targets)


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fix tensor shape issues when `cat_emb_dim>1` in `TabNetRegressor`.

This issue was fixed for `TabNetClassifier` in #48 but it was not the for the regressor (probably an omission?).

**Does this PR introduce a breaking change?**

Not that I know of. `input_dim` should be equal to `network.post_embed_dim` when `cat_emb_dim=1`.

**What needs to be documented once your changes are merged?**

Nothing more.

**Closing issues**

closes #49