### PR TITLE
feat: add multi output regression

### DIFF
--- a/multi_regression_example.ipynb
+++ b/multi_regression_example.ipynb
@@ -155,19 +155,31 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### We will simulate 5 targets here to perform multi regression without changing anything!"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "n_targets = 8\n",
+    "\n",
     "X_train = train[features].values[train_indices]\n",
-    "y_train = train[target].values[train_indices].reshape(-1, 1)\n",
+    "y_train = train[target].values[train_indices]\n",
+    "y_train = np.transpose(np.tile(y_train, (n_targets,1)))\n",
     "\n",
     "X_valid = train[features].values[valid_indices]\n",
-    "y_valid = train[target].values[valid_indices].reshape(-1, 1)\n",
+    "y_valid = train[target].values[valid_indices]\n",
+    "y_valid = np.transpose(np.tile(y_valid, (n_targets,1)))\n",
     "\n",
     "X_test = train[features].values[test_indices]\n",
-    "y_test = train[target].values[test_indices].reshape(-1, 1)"
+    "y_test = train[target].values[test_indices]\n",
+    "y_test = np.transpose(np.tile(y_test, (n_targets,1)))"
    ]
   },
   {
@@ -267,61 +279,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# XGB"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "from xgboost import XGBRegressor\n",
+    "# XGB : unfortunately this is still not possible with XGBoost\n",
     "\n",
-    "clf_xgb = XGBRegressor(max_depth=8,\n",
-    "    learning_rate=0.1,\n",
-    "    n_estimators=1000,\n",
-    "    verbosity=0,\n",
-    "    silent=None,\n",
-    "    objective='reg:linear',\n",
-    "    booster='gbtree',\n",
-    "    n_jobs=-1,\n",
-    "    nthread=None,\n",
-    "    gamma=0,\n",
-    "    min_child_weight=1,\n",
-    "    max_delta_step=0,\n",
-    "    subsample=0.7,\n",
-    "    colsample_bytree=1,\n",
-    "    colsample_bylevel=1,\n",
-    "    colsample_bynode=1,\n",
-    "    reg_alpha=0,\n",
-    "    reg_lambda=1,\n",
-    "    scale_pos_weight=1,\n",
-    "    base_score=0.5,\n",
-    "    random_state=0,\n",
-    "    seed=None,)\n",
-    "\n",
-    "clf_xgb.fit(X_train, y_train,\n",
-    "        eval_set=[(X_valid, y_valid)],\n",
-    "        early_stopping_rounds=40,\n",
-    "        verbose=10)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "preds = np.array(clf_xgb.predict(X_valid))\n",
-    "valid_auc = mean_squared_error(y_pred=preds, y_true=y_valid)\n",
-    "print(valid_auc)\n",
-    "\n",
-    "preds = np.array(clf_xgb.predict(X_test))\n",
-    "test_auc = mean_squared_error(y_pred=preds, y_true=y_test)\n",
-    "print(test_auc)"
+    "https://github.com/dmlc/xgboost/issues/2087"
    ]
   }
  ],


### PR DESCRIPTION


**What kind of change does this PR introduce?**

This PR allows to do multi target regression using TabnetRegressor without anything specific to do.

This feature emerged from this Kaggle discussion https://www.kaggle.com/c/trends-assessment-prediction/discussion/154165 where it seems useful to have multi target regression implemented

I did some tests and everything seems to be working fine!


<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**
There is one small breaking change, when doing single target regression you now need to pass your input target with shape (n, 1) and can't use (n,) there is a clear error for this new behaviour and I believe it is a very small change for users (migration would consist in putting a reshape(-1,1) to existing codes)

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

I also added a "fake" multi task regression notebook so that people would know it's feasible.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

**Closing issues**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
