### PR TITLE
fix: verbosity with schedulers

### DIFF
--- a/census_example.ipynb
+++ b/census_example.ipynb
@@ -151,7 +151,10 @@
     "                       cat_dims=cat_dims,\n",
     "                       cat_emb_dim=1,\n",
     "                       optimizer_fn=torch.optim.Adam,\n",
-    "                       optimizer_params=dict(lr=2e-2))"
+    "                       optimizer_params=dict(lr=2e-2),\n",
+    "                       scheduler_params={\"step_size\":50, # how to use learning rate scheduler\n",
+    "                                         \"gamma\":0.9},\n",
+    "                       scheduler_fn=torch.optim.lr_scheduler.StepLR)"
    ]
   },
   {
@@ -224,6 +227,16 @@
     "# plot auc\n",
     "plt.plot([-x for x in clf.history['train']['metric']])\n",
     "plt.plot([-x for x in clf.history['valid']['metric']])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot learning rates\n",
+    "plt.plot([x for x in clf.history['train']['lr']])"
    ]
   },
   {
@@ -369,7 +382,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase.  -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**
This solves #137.

I also improved the history so that the learning rates applied at each epoch can be displayed after the training.

I also made the intermediate results accessible from the outside with `self.` so that plots can be made even if training is stopped by KeyboadInterrupt
<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?**

Nope no breaking change
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**
I updated census example to show how to use schedulers and how to plot learning rates
<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

**Closing issues**
closes #137 
Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
