### PR TITLE
chore: update example notebooks

### DIFF
--- a/census_example.ipynb
+++ b/census_example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -15,7 +15,6 @@
     "import pandas as pd\n",
     "import numpy as np\n",
     "np.random.seed(0)\n",
-    "\n",
     "\n",
     "import os\n",
     "import wget\n",
@@ -34,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,18 +65,209 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "train = pd.read_csv(out)\n",
-    "target = ' <=50K'\n",
+    "# column headers/feature names\n",
+    "feature_names = [\"age\", \"workclass\", \"fnlwgt\", \n",
+    "                        \"education\", \"education_num\", \n",
+    "                        \"marital_status\", \"occupation\",\n",
+    "                        \"relationship\", \"race\", \"sex\", \n",
+    "                        \"capital_gain\", \"capital_loss\", \n",
+    "                        \"hours_per_week\", \"native_country\", \"income\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train = pd.read_csv(out,header=None,names=feature_names)\n",
+    "target = \"income\" #' <=50K'\n",
     "if \"Set\" not in train.columns:\n",
     "    train[\"Set\"] = np.random.choice([\"train\", \"valid\", \"test\"], p =[.8, .1, .1], size=(train.shape[0],))\n",
     "\n",
     "train_indices = train[train.Set==\"train\"].index\n",
     "valid_indices = train[train.Set==\"valid\"].index\n",
     "test_indices = train[train.Set==\"test\"].index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>age</th>\n",
+       "      <th>workclass</th>\n",
+       "      <th>fnlwgt</th>\n",
+       "      <th>education</th>\n",
+       "      <th>education_num</th>\n",
+       "      <th>marital_status</th>\n",
+       "      <th>occupation</th>\n",
+       "      <th>relationship</th>\n",
+       "      <th>race</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>capital_gain</th>\n",
+       "      <th>capital_loss</th>\n",
+       "      <th>hours_per_week</th>\n",
+       "      <th>native_country</th>\n",
+       "      <th>income</th>\n",
+       "      <th>Set</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>39</td>\n",
+       "      <td>State-gov</td>\n",
+       "      <td>77516</td>\n",
+       "      <td>Bachelors</td>\n",
+       "      <td>13</td>\n",
+       "      <td>Never-married</td>\n",
+       "      <td>Adm-clerical</td>\n",
+       "      <td>Not-in-family</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>2174</td>\n",
+       "      <td>0</td>\n",
+       "      <td>40</td>\n",
+       "      <td>United-States</td>\n",
+       "      <td>&lt;=50K</td>\n",
+       "      <td>train</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>50</td>\n",
+       "      <td>Self-emp-not-inc</td>\n",
+       "      <td>83311</td>\n",
+       "      <td>Bachelors</td>\n",
+       "      <td>13</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>Exec-managerial</td>\n",
+       "      <td>Husband</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>13</td>\n",
+       "      <td>United-States</td>\n",
+       "      <td>&lt;=50K</td>\n",
+       "      <td>train</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>38</td>\n",
+       "      <td>Private</td>\n",
+       "      <td>215646</td>\n",
+       "      <td>HS-grad</td>\n",
+       "      <td>9</td>\n",
+       "      <td>Divorced</td>\n",
+       "      <td>Handlers-cleaners</td>\n",
+       "      <td>Not-in-family</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>40</td>\n",
+       "      <td>United-States</td>\n",
+       "      <td>&lt;=50K</td>\n",
+       "      <td>train</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>53</td>\n",
+       "      <td>Private</td>\n",
+       "      <td>234721</td>\n",
+       "      <td>11th</td>\n",
+       "      <td>7</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>Handlers-cleaners</td>\n",
+       "      <td>Husband</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>40</td>\n",
+       "      <td>United-States</td>\n",
+       "      <td>&lt;=50K</td>\n",
+       "      <td>train</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>28</td>\n",
+       "      <td>Private</td>\n",
+       "      <td>338409</td>\n",
+       "      <td>Bachelors</td>\n",
+       "      <td>13</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>Prof-specialty</td>\n",
+       "      <td>Wife</td>\n",
+       "      <td>Black</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>40</td>\n",
+       "      <td>Cuba</td>\n",
+       "      <td>&lt;=50K</td>\n",
+       "      <td>train</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   age          workclass  fnlwgt   education  education_num  \\\n",
+       "0   39          State-gov   77516   Bachelors             13   \n",
+       "1   50   Self-emp-not-inc   83311   Bachelors             13   \n",
+       "2   38            Private  215646     HS-grad              9   \n",
+       "3   53            Private  234721        11th              7   \n",
+       "4   28            Private  338409   Bachelors             13   \n",
+       "\n",
+       "        marital_status          occupation    relationship    race      sex  \\\n",
+       "0        Never-married        Adm-clerical   Not-in-family   White     Male   \n",
+       "1   Married-civ-spouse     Exec-managerial         Husband   White     Male   \n",
+       "2             Divorced   Handlers-cleaners   Not-in-family   White     Male   \n",
+       "3   Married-civ-spouse   Handlers-cleaners         Husband   Black     Male   \n",
+       "4   Married-civ-spouse      Prof-specialty            Wife   Black   Female   \n",
+       "\n",
+       "   capital_gain  capital_loss  hours_per_week  native_country  income    Set  \n",
+       "0          2174             0              40   United-States   <=50K  train  \n",
+       "1             0             0              13   United-States   <=50K  train  \n",
+       "2             0             0              40   United-States   <=50K  train  \n",
+       "3             0             0              40   United-States   <=50K  train  \n",
+       "4             0             0              40            Cuba   <=50K  train  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train.head()"
    ]
   },
   {
@@ -91,9 +281,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "age 73\n",
+      "workclass 9\n",
+      "education 16\n",
+      "education_num 16\n",
+      "marital_status 7\n",
+      "occupation 15\n",
+      "relationship 6\n",
+      "race 5\n",
+      "sex 2\n",
+      "capital_gain 119\n",
+      "capital_loss 92\n",
+      "hours_per_week 94\n",
+      "native_country 42\n",
+      "income 2\n",
+      "Set 3\n"
+     ]
+    }
+   ],
    "source": [
     "nunique = train.nunique()\n",
     "types = train.dtypes\n",
@@ -121,9 +333,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "categoricals embeddings dimensions: [37, 5, 9, 9, 4, 8, 4, 3, 2, 50, 47, 48, 22]\n"
+     ]
+    }
+   ],
    "source": [
     "unused_feat = ['Set']\n",
     "\n",
@@ -131,7 +351,12 @@
     "\n",
     "cat_idxs = [ i for i, f in enumerate(features) if f in categorical_columns]\n",
     "\n",
-    "cat_dims = [ categorical_dims[f] for i, f in enumerate(features) if f in categorical_columns]\n"
+    "# cat_dims = number of unique values in variable/column\n",
+    "cat_dims = [ categorical_dims[f] for i, f in enumerate(features) if f in categorical_columns]\n",
+    "\n",
+    "# define your embedding sizes : A good heuristic is half the number of unique values, up to a maximum of 50. Here our variables have low cardinality. Note that `Set` isn't a feature\n",
+    "cat_emb_dim = [min(v//2+1,50) for v in categorical_dims.values()][:-2] # last 2 variables are target and Set indicator\n",
+    "print(\"categoricals embeddings dimensions:\",cat_emb_dim) "
    ]
   },
   {
@@ -143,9 +368,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Device used : cuda\n"
+     ]
+    }
+   ],
    "source": [
     "clf = TabNetClassifier(cat_idxs=cat_idxs,\n",
     "                       cat_dims=cat_dims,\n",
@@ -168,7 +401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,16 +426,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
-    "scrolled": false
+    "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Will train until validation stopping metric hasn't improved in 20 rounds.\n",
+      "---------------------------------------\n",
+      "| EPOCH |  train  |   valid  | total time (s)\n",
+      "| 1     | 0.68724 |  0.72008 |   5.2       \n",
+      "| 2     | 0.82084 |  0.80851 |   9.0       \n",
+      "| 3     | 0.87181 |  0.83926 |   12.7      \n",
+      "| 4     | 0.88985 |  0.87240 |   16.2      \n",
+      "| 5     | 0.89602 |  0.88669 |   19.8      \n",
+      "| 6     | 0.90584 |  0.89925 |   23.3      \n",
+      "| 7     | 0.90790 |  0.90305 |   26.9      \n",
+      "| 8     | 0.91442 |  0.90646 |   30.6      \n",
+      "| 9     | 0.91674 |  0.90880 |   34.3      \n",
+      "| 10    | 0.91813 |  0.90964 |   37.9      \n",
+      "| 11    | 0.92201 |  0.91584 |   41.5      \n",
+      "| 12    | 0.92682 |  0.91733 |   45.1      \n",
+      "| 13    | 0.92639 |  0.92029 |   48.9      \n",
+      "| 14    | 0.92902 |  0.91958 |   52.7      \n",
+      "| 15    | 0.92799 |  0.91846 |   56.4      \n",
+      "| 16    | 0.93095 |  0.91424 |   60.0      \n",
+      "| 17    | 0.93176 |  0.92001 |   63.6      \n",
+      "| 18    | 0.93145 |  0.91596 |   67.1      \n",
+      "| 19    | 0.92915 |  0.92250 |   70.7      \n",
+      "| 20    | 0.92955 |  0.92265 |   74.3      \n",
+      "| 21    | 0.93497 |  0.92163 |   77.9      \n",
+      "| 22    | 0.93211 |  0.92120 |   81.6      \n",
+      "| 23    | 0.93500 |  0.92031 |   85.4      \n",
+      "| 24    | 0.93317 |  0.92137 |   89.1      \n",
+      "| 25    | 0.93393 |  0.92613 |   92.9      \n",
+      "| 26    | 0.93573 |  0.92352 |   96.6      \n",
+      "| 27    | 0.93474 |  0.92662 |   100.3     \n",
+      "| 28    | 0.93587 |  0.92444 |   104.0     \n",
+      "| 29    | 0.93428 |  0.92282 |   107.7     \n",
+      "| 30    | 0.93850 |  0.92354 |   111.4     \n",
+      "| 31    | 0.93787 |  0.92221 |   115.1     \n",
+      "| 32    | 0.93707 |  0.92307 |   118.9     \n",
+      "| 33    | 0.93634 |  0.92388 |   122.6     \n",
+      "| 34    | 0.93845 |  0.92383 |   126.2     \n",
+      "| 35    | 0.93696 |  0.92291 |   129.9     \n",
+      "| 36    | 0.93777 |  0.92326 |   133.5     \n",
+      "| 37    | 0.93647 |  0.92524 |   137.3     \n",
+      "| 38    | 0.93761 |  0.92391 |   140.9     \n",
+      "| 39    | 0.93741 |  0.92466 |   144.6     \n",
+      "| 40    | 0.93629 |  0.92180 |   148.3     \n",
+      "| 41    | 0.93771 |  0.92451 |   151.9     \n",
+      "| 42    | 0.93965 |  0.92491 |   155.4     \n",
+      "| 43    | 0.93882 |  0.92401 |   158.9     \n",
+      "| 44    | 0.93695 |  0.92130 |   162.5     \n",
+      "| 45    | 0.93960 |  0.92269 |   166.1     \n",
+      "| 46    | 0.93745 |  0.92390 |   169.6     \n",
+      "| 47    | 0.93925 |  0.92283 |   173.2     \n",
+      "Early stopping occured at epoch 47\n",
+      "Training done in 173.176 seconds.\n",
+      "---------------------------------------\n"
+     ]
+    }
+   ],
    "source": [
     "clf.fit(\n",
     "    X_train=X_train, y_train=y_train,\n",
     "    X_valid=X_valid, y_valid=y_valid,\n",
-    "    max_epochs=max_epochs , patience=20,\n",
+    "    max_epochs=max_epochs, patience=20,\n",
     "    batch_size=1024, virtual_batch_size=128,\n",
     "    num_workers=0,\n",
     "    weights=1,\n",
@@ -212,9 +505,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1d22da352c8>]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAD4CAYAAADiry33AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd3iUVfbA8e/JpIeQRkIKgQCh964iCoqCBRFXFGxr2WVZy66rW9zd3/ZdV9dtrmWxLHbFLqgIFlRABQm9hBJ6CCGhk0Dq3N8fd4aEMEkmdZLJ+TwPz2Teed83N7PumTvn3nuuGGNQSinlvwJ83QCllFJNSwO9Ukr5OQ30Sinl5zTQK6WUn9NAr5RSfi7Q1w3wpEOHDiYtLc3XzVBKqVZj5cqVB40x8Z5ea5GBPi0tjYyMDF83QymlWg0R2V3da5q6UUopP6eBXiml/JwGeqWU8nMa6JVSys9poFdKKT+ngV4ppfycBnqllPJzfhPojTH857NtfLk139dNUUqpFsVvAr2I8MziHXy+Oc/XTVFKqRbFbwI9QExEMEdOlvi6GUop1aL4VaCPjQjmcKEGeqWUqkwDvVJK+TkN9Eop5ef8MtDrhudKKVXB7wJ9cZmTkyXlvm6KUkq1GH4X6AFN3yilVCVeBXoRmSgiW0QkS0QeqOacsSKyRkQ2isiXlY7vEpH1rteadDeR2HAN9EopVVWtO0yJiAN4ArgEyAZWiMg8Y8ymSudEA08CE40xe0QkocptxhljDjZiuz2KbaeBXimlqvKmRz8SyDLG7DDGlABzgMlVzrkBeMcYswfAGOOT5anao1dKqbN5E+hTgL2Vnme7jlXWE4gRkS9EZKWI3FLpNQN87Do+o7pfIiIzRCRDRDLy8+tXr0Z79EopdTZvNgcXD8eqzl8MBIYBFwNhwDcisswYsxUYbYzJcaVzPhGRzcaYxWfd0JingacBhg8fXq/5kZEhgQQ5hMNaBkEppU7zpkefDaRWet4JyPFwzgJjTKErF78YGARgjMlxPeYB72JTQU1CRIgJD+ZwgQZ6pZRy8ybQrwB6iEhXEQkGpgHzqpwzFxgjIoEiEg6MAjJFJEJEIgFEJAK4FNjQeM0/W2xEsPbolVKqklpTN8aYMhG5G1gIOIDZxpiNIjLT9fosY0ymiCwA1gFO4FljzAYR6Qa8KyLu3/WqMWZBU/0xoGUQlFKqKm9y9Bhj5gPzqxybVeX5I8AjVY7twJXCaS6xEcFszDnenL9SKaVaNL9aGQvao1dKqar8MtAfO1VKabnT101RSqkWwS8DPcDRk6U+bolSSrUMfhvoNX2jlFKW/wV6LYOglFJn8L9Ar2UQlFLqDP4X6E+nbop93BKllGoZ/C7Qx5xO3ehgrFJKgR8G+iBHAO1DA7VHr5RSLn4X6MFd70Z79EopBf4c6LVHr5RSgF8Heu3RK6UU+HWg1x69UkqB3wb6EI4UlmJMvTaqUkopv+KngT6IknInBcVlvm6KUkr5nJ8G+hBAV8cqpRT4baAPAjTQK6UU+G2g1x69Ukq5eRXoRWSiiGwRkSwReaCac8aKyBoR2SgiX9bl2samFSyVUqpCrXvGiogDeAK4BMgGVojIPGPMpkrnRANPAhONMXtEJMHba5uCVrBUSqkK3vToRwJZxpgdxpgSYA4wuco5NwDvGGP2ABhj8upwbaOLCHYQ7Ajg8EkN9Eop5U2gTwH2Vnqe7TpWWU8gRkS+EJGVInJLHa5tdCJiF00VaKBXSqlaUzeAeDhWdSVSIDAMuBgIA74RkWVeXmt/icgMYAZA586dvWhWzWIjgjmiPXqllPKqR58NpFZ63gnI8XDOAmNMoTHmILAYGOTltQAYY542xgw3xgyPj4/3tv3Vio0I5pDm6JVSyqtAvwLoISJdRSQYmAbMq3LOXGCMiASKSDgwCsj08tomYevdaKBXSqlaUzfGmDIRuRtYCDiA2caYjSIy0/X6LGNMpogsANYBTuBZY8wGAE/XNtHfcgYN9EopZXmTo8cYMx+YX+XYrCrPHwEe8eba5hAbEcyJojJKypwEB/rlujCllPKK30bAGNcm4Ud1QFYp1cb5baCPcwV6HZBVSrV1fhvoY12B/ogGeqVUG+f3gV579Eqpts7vA73OvFFKtXV+G+ijw7QmvVJKgR8H+kBHANHhQRrolVJtnt8GerB16bWCpVKqrfPvQK8VLJVSyr8DfYxWsFRKKf8O9HFawVIppfw70MdGBHOksARjPJbAV0qpNsHvA32Z03C8qMzXTVFKKZ/x+0APOpdeKdW2+XWgj9FAr5RS/h3o4zTQK6WUfwf6mHCtYKmUUn4d6OPaaQVLpZTyKtCLyEQR2SIiWSLygIfXx4rIMRFZ4/r320qv7RKR9a7jGY3Z+LOcOAAnck8/DQ8OJDQoQBdNKaXatFr3jBURB/AEcAmQDawQkXnGmE1VTl1ijLmymtuMM8YcbFhTa1FSCI8OghF3wIS/nD4cGx7MIS2DoJRqw7zp0Y8EsowxO4wxJcAcYHLTNqsegiOg+zhY/xY4y08fjm2nZRCUUm2bN4E+Bdhb6Xm261hV54rIWhH5SET6VTpugI9FZKWIzGhAW2s3YCoU5MKuJacPxYRrGQSlVNvmTaAXD8eq1hRYBXQxxgwCHgPeq/TaaGPMUOAy4C4RucDjLxGZISIZIpKRn5/vRbM86HUZBEfC+jdPH4qLCOZwYXH97qeUUn7Am0CfDaRWet4JyKl8gjHmuDGmwPXzfCBIRDq4nue4HvOAd7GpoLMYY542xgw3xgyPj4+v8x8CQFAY9JkEm+ZBaRHgqmBZWFq/+ymllB/wJtCvAHqISFcRCQamAfMqnyAiiSIirp9Huu57SEQiRCTSdTwCuBTY0Jh/wFkGToXi47BtIWB79AXFZRSXlddyoVJK+adaZ90YY8pE5G5gIeAAZhtjNorITNfrs4BrgR+KSBlwCphmjDEi0hF41/UZEAi8aoxZ0ER/i9X1QmjXEda9AX0nny6DcKSwlMQoR5P+aqWUaolqDfRwOh0zv8qxWZV+fhx43MN1O4BBDWxj3QQ4oP93YMWzcOrI6TIIhwqLSYwKbdamKKVUS+CfK2MHTIXyEtg0j9iIEADN0yul2iz/DPTJQyAuHda/SWxEEGB79Eop1Rb5Z6AXsb36XUuJcx4CtIKlUqrt8s9ADzbQY4jKmouIVrBUSrVd/hvo47pDyjAC1r+pq2OVUm2a/wZ6gAHXwYH1DA7Zr/VulFJtln8H+v7XgDiYJEu1gqVSqs3y70DfLgG6jeWC4i84Wljk69YopZRP+HegBxh4HXFlB+hUuN7XLVFKKZ/w/0Df+wpKA0K4qORLnM6qRTeVUsr/+X+gD4lkT/w4Lg9YxvHCQl+3Rimlmp3/B3ogr9sUYqSA4tWv+7opSinV7NpEoA/vM4ENzjTaffsolJf5ujlKKdWs2kSg75EYyX/KpxBRsBs2vO3r5iilVLNqE4E+PDiQrVFjyA7uBosfOWPzcKWU8ndtItAD9EyM4n8B18KhbbDxXV83Rymlmk2bCfS9EiN56fggnPG9Xb16p6+b5B2nE4xOC1VK1V+bCvRlTmHfwLshfzNkzvV1k2pXVgz/7AOPDoKPfgHbF9ljSilVB20n0HeMBGBF+AXQoSd82Qp69XmZUJALIe1h5fPw0hT4Wzd4/SZY/QoUHvR1C5VSrYBXgV5EJorIFhHJEpEHPLw+VkSOicga17/fenttc0nrEEGwI4AteSfhgp9B3kbY8qGvmuOd3HX28boX4Oc7Yfrrts5+9kqYeyf8ewCcOurbNiqlWrxaA72IOIAngMuAvsB0Eenr4dQlxpjBrn9/rOO1TS7IEUC3+Ai25J6AftdAbHf48uGWnf/evw6CIyGmKwSHQ6+JMOnfcN8muOpxKD0JB7f6upVKqRbOmx79SCDLGLPDGFMCzAEme3n/hlzb6HonRrI19wQ4AuGCn0Lueti6wFfNqV3uOkjsDwFV/mcSgS7n2Z8PZTV/u5RSrYo3gT4F2FvpebbrWFXnishaEflIRPrV8VpEZIaIZIhIRn5+vhfNqrueiZHkHCvi2KlSmwKJSWu5vXpnOeRugMQBnl+P7gwBgRrolVK18ibQi4djVSPjKqCLMWYQ8BjwXh2utQeNedoYM9wYMzw+Pt6LZtVd70Q7ILvtwAlwBMGY+yFnNWz7pEl+X4Mc3gGlhZA40PPrjiD7QaWBXilVC28CfTaQWul5JyCn8gnGmOPGmALXz/OBIBHp4M21zamna+bN5twT9sDAaRDVGZY94asmVW//WvuYVE2gBzvOcGh787RHKdVqeRPoVwA9RKSriAQD04B5lU8QkUQREdfPI133PeTNtc0pJTqMdiGBbD3gCvSBwdDzUjuLpaVNtcxdDwFBEN+n+nPi0m3Pv6W1XSnVotQa6I0xZcDdwEIgE3jDGLNRRGaKyEzXadcCG0RkLfAfYJqxPF7bFH+IN0SEnh3bVfTowaZGSk7A0V3e38jphNJTjd6+M+Sug4Te9sOoOnHd7cybE/ubti1KqVYt0JuTXOmY+VWOzar08+PA495e60u9Etvz0Yb9GGMQkYrBzv3rILabdzdZ8awdxL1vEwSGNH4jjbHt6Tmx5vPi0u3joSyI8jjGrZRSbWdlrFuvju04erKUvBOuUgIJfUEcFYuTvLF9EZw8CAea6MvJif32/jXl58H26EEHZJVSNWp7gT6xPYBdOAUQFArxvW1O3BvGQM4q+/P+NU3QQmxvHqqfWukWmQyBYTZPr5RS1WiDgd7OvNlSOU+fNLAiuNbmeA4UHLA/56xu5Na5uL9ddOxf83kBAbZX3xJ79HuWwfbPfd0KpRRtMNDHRgQTHxnClgOVB2QH2OJhBXm138Ddmw+Pg5ym6tGvteMFoe1rP7elBvoPfwof3u/rViilaIOBHmwly60Hqsy8Ae/y9PtW2hWpA6+HvE1QWtT4DcxdX/1Cqari0uHILigvbfx21FfhITiwHo7sbJr3RylVJ20z0CfaQF/udC3SrTzzpjb7VkHHfpA6CpxltgpmYzp1FI7urn0g1i22u23H0T2N246G2L3UPhqnFl1TqgVom4G+YyRFpU72Hj5pD4RF29oxtfXonU6brkkeCslD7LHGztO7B4UTB3l3/ukpli1ohezOxRU/52/2XTuUUkBbDfSJVUohgE2V1NajP7wDio9BylD7wRAW0/h5eveHjbc9+spz6VuKnYuh21ib4srL9HVrlGrz2mSg79GxHSKcmadPGuQK5Ceqv9A9EJs81JYKTh7S+IF+/zpo1xHaJXh3fngshEa3nEB/fL9N16SPt2kl7dEr5XNtMtCHBwfSOTb8zCmWiQMBU/MiqH0rISjczrsHSBoM+ZmNO+CYu877gViwHzhx6S0n0O9aYh/TxtgSDtqjV8rn2mSgB5unP2uKJdScvtm3yvb8Ha7KEclD7EBoY62QLT0F+Vu8T9u4xbWgKpY7v7TfMBIH2IJsR3ZByUlft0qpNq3tBvrESHYeLKS4rNweaJ9s58ZXNyBbXmpfSx5acSx5sH10p3QaKi8TTHndevRge/THs5u+0Jo3di6BtPMhwGF79BideaOUj7XpQF/uNGzPK7QHRGyArS7Q52VCWZEdiHWLSrUfDo1VCqGuA7Fu7po3vi6FcGSXnRra9UL73F1iWfP0SvlU2w30rk1Ithw4XnEwcYAN6J4WH+1baR/d0yrBfjgkDW68Adn96yCkPUSn1e26ljLzZqcrP9/1AvsY193W1Nc8vVI+1WYDfVqHCIIdAWzJLag4mDQIyks890BzVtncc9VSxslDbCBrjLRJ7jr7YVN1M/DauNvk80C/GCISIL6Xfe4Ish9C2qNXyqfabKAPcgTQLT6CLbmVe/TuUggeKlnuW23TNlJlG9zkwTavnruhYQ1ylttB3doqVnoSEgntEuGQD1M3xthA33XMme+RzrxRyufabKAHu1n41gOVevRx3e30yaozb0pO2ro2lQdi3dypnIbm6Q9l2d2i6joQ6+brKZYHt9nCcO60jVt8H5u3Lyn0TbuUUm070PdMjGTf0VMcL3Ll5AMcto5N1QHZ3PW2157iIdC3T4HwDg0vheD+FlHXgVg3X1ex3Pmlfawa6BNcaw505o1SPuNVoBeRiSKyRUSyROSBGs4bISLlInJtpWO7RGS9iKwRkYzGaHRj6e0qhbCtaiXL3PU2FeF2eiDWQ6BvrBWy+9eCI7hiMVZdxaXbXalOHWlYO+pr1xI7Cymm65nH3TNv8jRPr5Sv1BroRcQBPAFcBvQFpotI32rOexi7EXhV44wxg40xwxvY3kbVs6OHmjdJA6H4uJ0q6Jazyu7m1D7J842Sh9gVsg1ZGJS7DhL62AHM+ji9raAP8vROp51x0/WCs8cwYrvZD7B8zdMr5Sve9OhHAlnGmB3GmBJgDjDZw3n3AG8DXuze0TKkRIfRLiSQrbkeVshWTt/sW+U5beOWPNiW5D1QzwFZ92bg9c3PQ8UUy8M+WCGbtxFOHT47bQN2FXFcD+3RK+VD3gT6FGBvpefZrmOniUgKMAWY5eF6A3wsIitFZEZ1v0REZohIhohk5Ofne9GshhMRenZsx/p9xyoOJvSzm4W7B2RPHbXBs/L8+aoaWrL4+D4bKJO8LE3sSUwaSIBv8vTussRpYzy/ntBbe/RK+ZA3gV48HDNVnv8b+IUxptzDuaONMUOxqZ+7RMRDtw+MMU8bY4YbY4bHx8d70azGcWHPBFbvPcr+Y6558EGhdh64e3DUHbxr6tFHJtn54/XN03u7GXhNAkNs6WRfBfrY7hCV4vn1+D52Y5TiAs+vK6WalDeBPhtIrfS8E5BT5ZzhwBwR2QVcCzwpIlcDGGNyXI95wLvYVFCLcdXgZIyBD9burziYOKAideNpRWxVpwdk69mjz10HSO2bgdfGF1Msy8tg11ee0zZup2febGmeNimlzuBNoF8B9BCRriISDEwD5lU+wRjT1RiTZoxJA94C7jTGvCciESISCSAiEcClQANXFjWurh0iGNQpirlr91UcTBwIJ/ZDQb4N3rHd7SYjNUkebANZXeeLGwNbF9iB2JB2df8DKovtbgdjTdUvXE1o/1ooOVFzoHfPJNI8vVI+UWugN8aUAXdjZ9NkAm8YYzaKyEwRmVnL5R2BpSKyFvgW+NAYs6ChjW5skwensGHfcbLyXKmFpEqbhdc2EOuWPMQOyHpaVVuT7Yvsh8moH9TtOk/i0m3QLWjG8XD3/Pnq8vNgp1zqzBulfMarefTGmPnGmJ7GmO7GmL+4js0yxpw1+GqMudUY85br5x3GmEGuf/3c17Y0Vw5MIkBg3hpXr96dQtn2CZzI8Tx/vqokd8niOubpl/zDTt0cNL1u13lyeoplM6Zvdi62A9jtahhXcQRCh5619+iP7oXVrzRu+5RSbXtlrFtC+1DO696BuWtzMMbY7fmiOsPa1+wJ3vTo2yfZejN1ydPv/gZ2fwWjf2QHUxuquatYlhXDnmW2vk1t4nvXXtzsk9/A3DsrxkWUUo1CA73LVYOT2X3oJGuzXVMtkwZC0VE71dLb+e3Jg+tW82bJ3235hKHfrXuDPYnqBI6Q5gv02RlQdqrm/LxbQm84trf6PXmP7YNNrqGfb59pvDYqpTTQu03sn0hwYABz3ekbd3BP6AvB4d7dJHmI3QrQm2mEOash61M4907v71+bAAfEdm2+DUj2fG0fO59b+7mnNyGpZuZNxv8AAz0vgw1vQ+HBRmmiUkoD/WntQ4O4qFcC76/dT1m5s2JOe0oN0yqrShoMGO8GZJf8A0KiYMT36tXeajXnFMs9y2wAD4+t/dwEd80bDwOypUWw8nnodTlc8ge7J8DK5xuzpUq1aRroK7l6SDIHC4r5Zschm5d3hECaF2kJt9N7yNaSp8/bDJnvw6gZEBpV/wZ7Etfd9uidntauNSJnOez9Fjqf4935MWkQGOo5T7/hbTh5yM48iu8F3cZCxmw7R18p1WAa6CsZ2yuByJBA5q7JgchE+MlGGHBt7Re6RSba1anL/1t9igJg6b9s3ftRP2x4o6uKS7c94mN7az+3IfIybfE3b9I2YNNKHXqc3aM3BpbPsiky9xTNkTNsWYgtHzZum5VqozTQVxIa5GBi/0QWbMilqLTcThmsWo2xNlOft6mIZy+BHV+c/frhnbD+TRh+O0TENUazzxTrnmLZxMXN9nxjHzuP8v6a+D5n9+j3LLPrFUbOqHive060H5g6KKtUo9BAX8XkwSkUFJfx+eZ6LjpKGQbf/8zWfXn5O2fnmr961PZuz727wW316PQUy6YO9MtsjZ/oLt5fk9Db9tSLKm3fuHyW3Yt34HUVxwIcduxi1xK7vaJSqkE00Fdxbvc44iNDeG/NvtpPrk50Z7h9oc01v/9j+Pg3tmb78RxY8woMuan62vYN1S4BgiObfkB273Kbn6/LN56qM2+OZduxiqG3QHDEmecOudnm9L99uuZ7lpXYb07NWfZBqVZGA30VjgBh0sBkPt+cz7FTpfW/UWh7mP46jPg+fP0feONmWPyIHcQc/ePGa3BVIrbnnPVJwzZCqcnRvXYMINXLgVg3d3EzdymEjNmA8TzzKDwWBkyFdW9Uv2tWWTG8+V14cbKdqqqU8kgDvQeTBydTUu5k4Ybcht3IEQhX/B0u+xtsmW8D24CpdgZKU7ro/+zMm8/+2DT337vcPno748YtOg0Cw+yso9JTkPGcnVIZU036Z+QMu2G6p7IIpUXw+k32fQVbk0gp5ZEGeg8GdooiLS78zIqWDTHqBzB9DnQaCRf+vHHuWZNuY22QXP7fik1BGtOeZRDcru5llQMCIL6n7dFveNtutlJTMbekgXZWz4pnbOrLreQkvDbN1iKa9Kgdl6i6obtS6jQN9B6ICFcNTuHr7YfIO17UODftOQG+90lF4bGmNv4PdgbOe3edOfjZGPYsg07D7TeWuorvbXv0VadUVmfkDLt/b9Yn9nlJIbx6nc3LT34Cht3q2tBdA71S1dFAX43Jrg1JHpyfaQudtTbB4TDlKTieDQt/1Xj3LTpm98b1dv58VfG9bUXQ3PW2N1/bYG6fSXZ2z7dP2zo5L19rC8FNeQqG3GjPSRpod7CqLpevVBungb4a3ePb8dNLe/Lemhz+9clWXzenflJHwOh7YfVLsHVh49wzewVg6p6fd3OXQgiNhgHX1XwugCPIrjnI+hSeu8yOD3znWRh0fcU5pzd0r+NeAEq1ERroa3DXuHSuH57KfxZl8UZGE680bSpjH7C59Hn3wMnDDb/fnmW2omfK8Ppd37GffRx6i/fF3IZ+FwKC7Kraqc9B/++c+Xqia1P1/Zq+UcoTDfQ1EBH+PKU/Y3p04FfvrGfptlZYUTEwBKbMskH+w/safr89y2wPur7bHkZ3hpvfg7G/9P6ayI62F3/ze9B38tmvt4u36Z3GyNOXFcOe5Q2/j1ItiAb6WgQ5AnjixqGkJ7Tjhy+vZHNuIw9sNofEAbZnv/FdWP9W/e9TXmpr0Nc3P+/WfVzdSzP3u7rmDU4SBzZO6ubj/4PZl9qCbUr5Ca8CvYhMFJEtIpIlIg/UcN4IESkXkWvrem1L1j40iNm3jiA8xMHtz63gQGPNxGlOo++FTiPgw/vhyO763WP/OrvRSF3q2zSXxAF2xW3pqfrfI2cNrHjW/vzVo43TLqVagFoDvYg4gCeAy4C+wHQR6VvNeQ9jNxGv07WtQXJ0GLNvHcGxU6Xc/vwKCotbWQldRyBcPcuWCpg9EQ5sqvs93IXM6roitjkkDQRTDnn1+LvAztOf/1MIi7VTOjd/CAebce9dpZqQNz36kUCWa6PvEmAO4CFRyj3A20BePa5tFfolR/H4jUPZnHuCe15bjdPZyqZddkiH2z8CDDw3EXZ/Xbfr9y6zq3qbqk5PQ7h3BKvvgOyal+2Mokv/BBf8HBzB8M1jjdc+pXzIm0CfAlSecpLtOnaaiKQAU4BZdb220j1miEiGiGTk5+d70SzfGNcrgd9P6suizXnMWtzEFSKbQsd+cMfHEJEAL02xPVdvGGMHYltibx7sB1BIVP0GZE8ehk9+Z8ceBk23g7uDb4A1r0FBPauYKtWCeBPoPa1oqdqV/TfwC2NM1W2NvLnWHjTmaWPMcGPM8Pj4eC+a5Ts3ndOFKwYk8Y+Pt7JqTytcpOOurtmxv60X4822fYd3QGF+/efPNzURm6evz4DsZ3+0C8Eu/3vFAq7z7rEbuCx/qnHbqZQPeBPos4HUSs87ATlVzhkOzBGRXcC1wJMicrWX17Y6IsKD1wwgsX0oP3ptNceLGlDl0lci4uC78yB9vC2l/MXDNZf63bPMPjZ0xk1TShxg69fXZRvFfSvtB92oH0Bipdo9cd2hz5V2cNabzd6VasG8CfQrgB4i0lVEgoFpwLzKJxhjuhpj0owxacBbwJ3GmPe8uba1igoL4j/Th7D/WBG/emd9Ky2TEAHTXoVBN8AXD8IHP7FTKD3Z841dzdqhZ/O2sS6SBtpql97W4neW21lI7Tp6ntd/3o+h6KhdWaxUK1ZroDfGlAF3Y2fTZAJvGGM2ishMEZlZn2sb3uyWYViXGO67pCcfrNvPmxnZvm5O/TiC4Oon4fyfwMrn4Pkr4YSH8sx7ltm0TUALXnpR1wHZVS/Yjdwn/MXuH1BV6gjofB5886RuVK5aNa/+X2uMmW+M6WmM6W6M+Yvr2CxjTNXBV4wxtxpj3qrpWn8y88LunNc9jt/N20hWXiv9ii8C438P3/mfHcycNQZ2fVXxeuFBOLSt5ebn3eJ72dkyuWtrP7fwEHz6B1s9s2pJhcpG/wiO7YFN7zVeO5VqZi24e9Y6OAKEf10/mLBgB/e8ttpuKt5aDbgWvr/I9m5fmATfPGHz9u6NRlrqjBs3R5AtmubNgOynv4OSgjMHYD3pMcGmq776t25XqFotDfSNoGP7UP4+dSCZ+4/z0Eebfd2chknoA9//HHpdZssbv3WbrRzpCIbkIb5uXe0SB9rUTU1B+dB2WP0yjJpZsb1hdQIC4Lwf2Q+PHV80alObzeqX4ZF0W+ZZtUka6BvJRb07ctvoNJ7/ehePfrqNtXuPUlrurOF5kAUAACAASURBVP3Clii0PVz/MlzyR9g0126BmDwUgkJ93bLaJQ2yO1cdr2F3sIzZEOCwUyi9MfA6aJfYessirH7FTo3d9rGvW6J8pB5bBKnqPHBZbzL3H+dfn27lX59uJTQogEGdohnWJYZhXWIY2jmGmIhgXzfTOyJ2E/OkwfDuTLsBSGtQeUA2qtPZr5cU2lk0fSdDZKJ39wwMsdMvP/uDvW/SwMZrb1MryK8oXbFpXs3jEcpvaaBvRCGBDubMOJf9x06xavdRVu4+wso9R3h68Q7KnIYgh/DUzcO4qHdHXzfVe90uhPvqWT/GFzr2A8QOKve+/OzX179pF0eN+H7d7jv8dljyD/jkNzD99dbx7QZcm6cbSB1l99gtPQVBYb5ulWpmmrppAklRYVwxMInfTurL3LtGs/73E3h9xjn0SIjk3jlr2HPopK+bWDcitW/511KEtLOLnTwNyBoD3z4DHQfUfQZRWLSdhrnjC3h1auvJd2e+D9FdbJnq0kLI+szXLVI+oIG+GYQFOxjVLY5ZNw0DYObLK1v37JyWzj0gW9Web+x+tyO/X78PrmG3wpSn7dTTF65qnB27mlLRcdj5pU27pY2xC94y3/d1q9qGuXfBoj/7uhWnaaBvRp3jwvn3tMFs2n+c37y3oXWupm0Nkgbaue9VA/G3T0NoFAyYWv97D7oepr1iSy08dxkcb8EVPbZ9bOv19Jlkp572vgK2fARlJb5umX87ddQWxFvyTzvDqwXQQN/MLurdkR9dlM6bK7OZs6KV7kPb0rkHZCunb47n2N7skJvrvrtVVb0ug5vehmP7YPaEFvN/5rNkvm/LO3QaaZ/3mQTFx2DnYt+2y9/tXGz3RjDl8MVffd0aQAO9T/x4fE/G9OjA7+ZuZF32UV83x/+cDvSV0jcrn7e1bUbc0Ti/o+sYWxSuuMBu5JK7oXHu21hKi+zga6/LK8pWdBsHwe0g0y/KTbVc2z+D4Eg49267decB31d90UDvA44A4dFpQ4iPDOGHL6/iSKF+lW5UpzcLd/Xoy0psoO9xKcR2a7zfkzIUbl9g0yLPXw55mY1374ba8bkdfO1zZcWxoFDoOcHuQVCXCp/Ke8ZA1iLoegGMuR9C2sMi31d+0UDvI7ERwTx541DyTxTz49fXUN7adqtq6SoPyGbOg4IDdovAxhbfywb7gEB4/96WUyYh8wO7EUvaBWce7zMJTh6s++5iyjuHsuz4UPpFEB4Lo++BLR9CdoZPm6WB3ocGpUbzu6v6snhrPr98Zx1Ltx3k2KlWWNu+JUoaCAe32nnj3z5je/LdL2qa3xXdGcb/wW61uHZO0/yOuigvs/Pne06AwCoL9NIvgcBQnX3TVNzTV7tfbB9H/RDCO9jNbXxIF0z52A0jO7N5/wleWrabN1yljrt2iGBgpygGpEQxKDWawanRBDn0M7lOEgfYwbC1c2wAnvDXpi2xPPhGW/b4k9/Ywdqw6Kb7XbXZ87UtA1E5beMW0s5uNpP5Pkx8qGWXnW6Ntn9mOxWxXe3zkHY2hbPwl3YNRrexPmmW/q/sYyLCn67uz5rfXsJLd4zkZxN60SOhHd/uPMyfP8xk6qxvGP3QIv758RZyjp7ydXNbD/eA7Ke/h6BwuwdsUwoIsJUwTx6Czx9s2t9Vm8wPbK89fbzn1/tcBSdy7O5adeUsh4W/tgPQWxa0nFRVS1BWDLuWVvTm3YbfDu1T4LM/+ez90h59CxEdHsyYHvGM6VGxX27eiSJW7jrCmyuzeezzLB7/PIuLeidw46guXNAzHkdAK1mt6gvuzcKLjsKw25qnh508GIbfASuegSE3+aYmjjGw+QMbbIIjPJ/TcwIEBNmxi9QR3t+7pBDeugO2fgQR8fDa9bYW0thf2nu2ltXTTWXPMrvDWdUUYVAoXPgLeP9HsHWB/cbXzLRH34IlRIZy2YAkZt86gsU/G8edY9NZs/cYtz2/ggv+9jn//WI7p0p09oRH7s3Cwa6EbS4X/RrCYmH+T8Hpg+qlOats5U5PaRu3sGhbwyhznvc9zBMH4LnLYdtC+83lvkyY/IT9IH3tenh6rPbwt39mB+W7jjn7tcE3QGx326v3wX8XGuhbidTYcH46oRdfP3ART9wwlC5x4Ty8YDPj//kl89fv11W2ngy7Fc65y1XorJmExdjyznuXw9rXGv/++1bB5vnVB9TMD0Ac0HNizffpcxUc2eXdJi15mfDseDu4Pe01+8HpCLLfWu7OODvgH9xWt7/JmPp9QLS0/+azFtnNeUIiz37NEQTjfgV5G2HjO83eNPEmQIjIROBRwAE8a4x5qMrrk4E/AU6gDLjXGLPU9dou4ARQDpQZY4bX9vuGDx9uMjJ8Ox2pNfh252F+N28jmfuPc173OH5/VT96dvTwH5lqXk4nPDfRrpi9J8MG/8ZQUgiPDYMT++3smSv/aWf8VPb4CLuG4Lu1LIoqPAh/72EHCi/6v+rP27kY5txk0w83vF795jPlpbDudfjoAfttYspZu4xW7/Wb7IfTdS94f83yp+GjnwFi9xYICLT3CAi0z8fcD+fd7f39GurEAfhHT7j4t/Z3e+J0wqzzoewU3Ln87BlRDSQiK6uLr7X26EXEATwBXAb0BaaLSN8qp30GDDLGDAZuB56t8vo4Y8xgb4K88t7IrrG8f/do/jS5HxtzjnPZo0v44/ubdIqmr7kHZk8dbtzFMsuetEF+1A/tPPgnzoFlsyoWP+Vvsb1ub/YOiOgAXUZXP83SGFuv5aVroH0SfO/TmncYc/fwe15qpxh6m54oPmFTPpnv2318vZUxGzr0ggt+ZncAG/UDGH6bTZHEdIEvHmreonM7PrePVQdiKwsIsB8Eh3fAk6Ng7evNtnDNm9TNSCDLGLPDGFMCzAEmVz7BGFNgKr4aRAAt7DuV/wp0BHDzuWl8/tOxXD8ilee+3snF//iC+ev3+7ppbVvSQFvzPuN/sN+LzcprU5APSx+F3lfCZQ/Bnd/YUssLfmHr7eRlVgTt3ld4d88+V0H+Zsjfanvk2Svh68dhzo1268H3ZtrfcfvCs785VCd9PBTm2Sqh3tjxJThL7VRYb0sz5GVCfqZNIV30axj/O5sum/AX+95cPcvuB/z1Y97drzFkfWbnyyfWMgDfa6JrP4MIeHcGPHkubHinyfP23gT6FKBy9a1s17EziMgUEdkMfIjt1bsZ4GMRWSki1S5NFJEZIpIhIhn5+fnetV6dFhsRzINTBvD+3eeTEhPOna+s4rmvdvq6WW3buF9BeBzM/1nD77X4b3ZGx/jf2+cxXWxhtSlP2xTRrDG2x58yHNone3dP94Dtq1Phoc7w7EXw8a9tkO5xKVz1ONz0Tt1mLLlnnGR96t352z62dWFiu3mfu97wDkiA3SXMk4TedqP75U/ZFFVTczph+yLoPs67dQm9JsIPFsPUF+ykgbdug6fG2PGVJhp38CbQe5ozdVZrjDHvGmN6A1dj8/Vuo40xQ7Gpn7tE5IKq17quf9oYM9wYMzw+Pt7TKcoL/VOieH3GOUzsl8gf3t/EPz7eogO1vhIWbfO1e5dDXgM2jT+03aYqht0KHXpUHBexZZPvXgH9rrZz+Ptf4/192yfDwGm2HsvQW2Dq83DfZvjxWpjyXxh6c93zyJGJdraTNxucGGM/ELqPhf7X2jnoBXm1X7PhbVtfv11C9edd+AubC2+MfX7Limt+PXedLStRU9qmqoAA+7/ZD7+Ga561K7hfvxGeGWd/bmTeBPpsILXS805AtUW4jTGLge4i0sH1PMf1mAe8i00FqSYUGuTgiRuHMm1EKo8tyuLX723QWjq+0m8KIHaT9fr67A/gCLG7RHkS0QG+8yzcswpGzazbva95CmYugcsetm1tn1T/drp1v9iuRq5tF668TDsVNP0S+wFlnLW/T7nr4PD22j/QOvSAAdfZ8he1fXjUpCAP/t4TPriv+t72dnfZg3qU2AhwwMCpcNe3cPV/ofO5TbLVozeBfgXQQ0S6ikgwMA04I5kmIukidrWEiAwFgoFDIhIhIpGu4xHApUALq+fqnxwBwl+vGcAPx3bn1eV7+NFrqyku0zn3zS4y0f6ft76Bfu8Ke+3oH9fcgwW7hWKAo36/pzGljwdnWe1177d9bB97XAIJfSC+j03L1GTDO3ZmTZ+ram/HhT+3G68s/bd37fZk3et26mjG/6qvV5O1yG5PGdmAvaAdgXYgeWLT1K+vNdAbY8qAu4GFQCbwhjFmo4jMFBF39+E7wAYRWYOdoXO9a3C2I7BURNYC3wIfGmMWNMUfos4mIvxiYm9+fXkfPly/nzuez6CwuMzXzWp7+k6286frM7/8k9/YzUPOvatp2tYUUkfZuve15emzPoWO/SvGFPpNsds9VrdrlzE2j99trK0MWZu47jBoug3Sx+sxOcEYWP0ydBphyxgs/efZqaDiEzY1131c3e/fjLwqgWCMmQ/Mr3JsVqWfHwYe9nDdDmBQA9uoGuj7F3QjOjyIB95Zz/RnlnHlwCTCggOJCHYQHhxIeLCDiBAHydFhJEU1/tfGNq/PJDs7ZtN7djqgt7bMt4Hvyn/Z4litRWCwrcee9akNlp5KIxQdt3/buZXmuve/Br54EDa+B+feefY1+1bB0T1wYTUpLE8u+CmsmwNL/wWX/61uf8e+lXZW0qRH7c5kRcfgk9/avXeHfdees2upnTWUXof8vA9orZs2YurwVKLDg7nv9TU8ON/zwKAIjO/Tke+d35WRXWORtl67pLFEpdhe7qa53gf68jL45HcQ1wOG3NK07WsK6RfbD6pD26FD+tmv7/zSpnd6XFpxrEMPmwLZ+I7nQL/xHXAEez99FGwVycE3wsrnbPor6qwJg9Vb/TIEhkG/a2xK7OpZNth/cK/de7jf1XbQOSjcpudaMA30bcglfTuy9neXcqq0nMKSMk6VlFNYXM7JkjIKS8pZsfMwryzfzSebDtA/pT13nN+VKwYkExzoOcNXVFpOYXEZce1CmvkvaYX6ToaFv7KBL6577eevfhEObYNpr9r8bWvjnoGS9annQL/tYzvbJ7XK3Iz+U2wu/OieM+fuO502P58+vu4F6i74Kax51aZerviHd9eUnLSze/pOhtD29lhgMFz3Erw0Bd7+nj2+/TNIOx8CW/b/B1rhf0GqIQIChIiQQCJCzv6f/sKe8dw1Lp13V+/jf0t38JPX1/LQR5u55dw0kqJC2XP4JHsOn2Sv6/HAcTvtbNKgZH4+oRepsQ3cdNuDcqdh4cZcnl2yg9Jyw+DU6NM1+rt1iCCgtVTw7HOVDfSb5sKY+2o+t7gAPv+r7SX2urx52tfYYrtCXLoN9OdUmQlkDGz71ObaHUFnvtbvGhvoN74Ho39UcXzvcltauV89NvCI7myniq58AUbfC9GptV+z+QMoPm5X+1YWHG5LQTx/Jbw2HcqKYOQP6t6mZqaBXp0hLNjBDaM6M21EKl9uy2f20p08snAL4CoI2T6U1NhwxvSIp3NsOIXFZbzwzS4WbszlttFp3DUunfahQTX/Ei+UljuZuyaH/36Rxfb8Qrp2iCApKpR3V+/jpWW7AYgMDWRQp2iGdYnhe2O6EtkIv7fJRKfaxUzeBPqvHrWrS6e92rpL/3a/GFa9aDcqDwqtOJ63yQbtymkbt9iuttTCxnfODPQb37E19nvVUqytOmPut6mYJX+3OffarH7JlrruMvrs18Ki4eZ37IrkwztafH4eNNCragQECON6JTCuVwK7DxVS7jSkxIQREnj29L1bR6fxyMItPPXlDt7MyObe8T2YPrJzvXbFKiot582V2Tz15Xayj5yid2Ikj00fwuUDknAECE6nYXt+AWv2HmXN3qOszT7KY4u2sWhzHs/fNqJlp5H6TrazaI7sskHEk2PZdul+/+/UrVZ8S5Q+Hr59yu54VXmOuXtaZXUbo/S7xr5Ph3fYFbPOcvsB2eNSz5UhvRHVyS44y5gN59xp9/qtzpHddmrouF9Xv9K1XQLcOt+Wha68iK2F8qp6ZXPT6pWt04Z9x/jzh5tYtuMw3eIjmDoslUBXasVUWkxtDBSVOjlZascJTpaU2/GCkjI25hwn/0QxQzpHc/e4dC7qnVDroPDnm/OY+fJKUmLCePmOUSRHt9CZQ0d2waODbF2W0T/2fM47M2za4p4M7+vLtFQlhfBwV1uTZkKl4m7PXWEHNX+41PN1R/fCv/tXVILcuRhemGRX7vabUv/2FOTBk+dAZLIt0lb5W0Zln/8VvnwY7l3vXZqnhaipeqUGetWojDF8mpnHXz/KZEd+YY3nBgcGEB7sIDzIQZhrqmdiVCi3jU7j3G5xdZr1s2LXYW5/fgWRIYG8eMco0hNa6HTEp8faOi3fX3T2a/tWwjMXwfn32UJd/uDFq23FzbuW2+dFx+FvXW3FyZr+xmcvsaUAfrgU3r8X1r0BP8uyOfKG2LoQXr3OriC+7KwZ4XbQ99FBdgD55ncb9ruaWU2BXlM3qlGJCJf07cj4PgkUFJedEawrh+2QwAACG3HD8xFpscyZcQ7fnf0t1z31DS/cNpIBnaI8nltUWs7qPUfpnhBBQmQ1vToPyp2GU6XlBAYIjgAhMEDqPgW172S7j23VWSXGwIJf2S36zv9J3e7ZkqVfDB//n01JRXWyG2Q7y+xq2Jr0vwYWPOCqyjnPbr/X0CAPdsvDc+60BeC6jT17W79di+HYHv/5oHXRQK+ahIg0++Bov+Qo3px5Hjc9u5zpzyzjmVuGc273OAByjxWxaHMeizYfYGnWQYpKnQQ7Apg0KJnbz0+jX7LnDwWAXQcLmbNiL2+t3MvBgpIzXnO4gn5YkINrh3Xi7nHpxETUUAjMHeg3zTtzY4xNc219mEmPVkzn8wfp422gz/rMLjLa9rHdy7dTLSWv+k6GBb+0NWbqWqytNuN/D7uWwHt32qJilev7rH7ZzpHvXcNWjK2Qpm6U38k9VsTN/1vO7sMnmT4ilYzdR9iYcxyATjFhjO/TkXO7x/F11kHeXJnNyZJyzukWyx3nd+Pi3gkEBAglZU4+2XSA177dw9KsgzgChIt7JzA8LYZyJ5SVOylzGsqcTsrKDfuOnmL++v1EhARy17h0bj0vjdCgaurOzBpjZ5B87xP7vLQInhhpywbMXOKxXo0xhjV7jzJ3TQ6RoYHcO75n69gc3hj4Vz9IGQbXvQj/7GsHma97sfZrZ19mB3JD2tu0TWPOVT+4DZ66wLbrlrn2PT91FP7Ry06p9Ha+fQuiqRvVpiRGhfLGD87ltudX8NKy3QzrEsMvJvbm4j4J9EhodzrdMqFfIvdd0os5K/bwwte7+P6LGaTFhTM6vQMLN+ZysKCElOgw7r+kJ1OHp5IYVXOaZ3PucR7+aDMPfbSZF7/exU8n9OLqwSlnz/XvOxkW/Yl9u7MIiu1E/NqnkKO74eb3zgryO/ILeG9NDnPX7GP3oZMEOYTScsOO/EL+ef0gj7OgWhQRO+Nm0zy7AUt10yo96X+NDfS9r2j8BUkdesDlj8Dcu+Crf9tB3w1v23nxVefO+wHt0Su/ZYzhZEm5x8VhVZWWO1mwIZf/Ld3J+n3HuLh3AtNHdeaCHvF17jl/nXWQBz/KZMO+4/RNas/0UZ05VFDM3sOn2HvkJHIwi9dL7+YPpTczr/w8vgi5jw2B/Xgy+UFSosNIiQ4jKDCAj9bvZ232MUTgvO5xTB6cwsT+ibyxYi9//jCT0elxPHXzcNp58ff51Mb34M3v2g3Lty6A+7fYqp61KTwIL10NV/yrTlNNj50sJSzYUe2K7tOMgbfvsO27fSF85Kp2OXNpq1y/oLNulKqD0nJnvdYAVOZ0Gt5fl8MjC7eQfeQUItAxMpTU2DBSY8L55e7vQUgkh9ul02Pv2/y5y2xWnoxn35GTp8cB+ia1Z8qQFCYNSj7r28Q7q7L52Vvr6JvUnuduG0GHBqwfMMZQWm4oLiunuMxp/5XaktZdO0Q0vObRqaPwt252u8DEATaQumzJPcHbq7IpLXdyad9ERqTF1GuQPv9EMQs27OeDdfv5dtdhOrQL4fbRXblhVGeiwmoYKyo6ZjfsLi2yi9Qm/NVznZ1WQAO9Uj5SUuYk91gRHaNCzkyzfPk3+PxBO9VyxB02jeBSVFrO8aLSWmcELdp8gDtfWUVSVBgv3j6y2hIUJWVOdhwsIPvwKbKPnCT7yCn776j9+dip0mr31OidGMlto9OYPDil+jEH7JjFV9sPsWBDLlFhQYxIi2FYlxiiw10D0/+bYAebx9zP8dG/5P21ObyxYi9rs48R5BACRCgucxITHsT4Ph2Z2D+R0ekdavydBwuKWbAhlw/X7Wf5zkM4DaQntGNCv46syz7Gkm0HaRcSyA2jOnP76K7Vp972rrCrXCUA7t9sN3KpwbGTpcxbu483V2az5/BJ7r24Bzefm+bzMRMN9Eq1NPlb4YkRdobHj9Z4V1/dg5W7D3PbcysIDXLw4h0j6Z3YntxjRazac4TVe46was9R1u87RklZxebToUEBdIoJp1NMGJ1iwogNDyYkyEFIYIDrn017nCgq5ZXle9ice4KY8CBuGNWZm89JOx0wjTFs2Hecd1fvY97aHA4WFNMuJJCi0nLKXDua9Uhox/C0GG4qfp1+Wx7nsS6P8cSOeIpKnfROjOS64alcPSSF0KAAvtySz4KNuSzKzONEcRkRwQ7G9IgnLNjBiaIyCovLKCwpo6CojILiMg4WFOM00C0+gisHJnPFgCR6dqwYg9mw7xhPL97BB+tycAQIVw9O4fsXdKNnRw+ra9e/BaeO2MVdHpQ7DV+5Bu8XbsylpMy2Pzo8iGU7DjM4NZqHvjOA3ok1z5jaknuCz7fkMSQ1mhFpsY1aq0kDvVIt0dy7IO0Cu+9rA2zJPcEts5dzsricdqGB7D9WBNgFaQNSohiSGs2ATlF0iYugU0wYcRHBXqdjjDEs23GY577aySeZB3CIcNmAJNLj2zFv7T625xcS7AhgXO94pgxJYVzvBJxOWJt9lJW7j5Cx6zAZu48QUHSUSY5vmBc4gUmDO3H9iFQGpER5bEdJmZOvtx9k4cYDLNmWjwhEBAcSGWqL8bVz/UuMCmVi/0R6dYys8e/Ze/gkzy7ZwesZeykqdZIcFcrQLjEM7xLDsC6x9E6KPCNVZ4zhYEEJuw8VsuvQSbYeOMH7a3PYf6yIqLAgrh6czNThqfRLtkF97poc/vjBJo6fKuUHF3bjnot6nPFNpLisnI/W5/LK8t2s2HXk9PHE9qFcOTCJqwYnV/te1IUGeqX8XPaRk/x+3kbCggMZkhrN0C4x9E1qX/uAZB3sOXSSF77ZxRsr9nKiuIyRabFcPSSFywckVqRoPHA6DdvyCsg5eopzusURFuybmUKHC0uYt2YfGbuPsGr3EXJcH4hhQQ4GpUYRGxHM7kMn2X3oJAWVdmJzBAjnp3dg6vBOjO/T0WM66XBhCX/+cBPvrNpH1w4RPDhlAElRobz27R7eXJnN4cISusSFc+Oozlw+IImVu4/w/tocvtyaT2m5IS0unEmDkpk0KNnzNw4vaKBXSjUadwqlLquKW6Kco6dYufvI6X8FxWV0iQsnLS7i9GNahwhSosO8/sBcsi2fX727nr2HTwH2Q+KSPh256ZwunNc97qxUzbGTpSzYuJ/31+7n6+0HiQwNIuP/xtdrMkCDA72ITAQeBRzAs8aYh6q8Phn4E+AEyoB7jTFLvbnWEw30SqnW6lRJObO/2okxhqnDU+nY3rsPxLwTRWw7UMDo9JoHg6vToEAvIg5gK3AJkA2sAKYbYzZVOqcdUGiMMSIyELuBeG9vrvVEA71SStVNTYHem+8HI4EsY8wOY0wJMAeYXPkEY0yBqfjEiIDTNWlrvVYppVTT8ibQpwB7Kz3Pdh07g4hMEZHNwIfA7XW51nX9DBHJEJGM/Px8b9qulFLKC94Eek9zfs7K9xhj3jXG9Aauxubrvb7Wdf3Txpjhxpjh8fHxXjRLKaWUN7wJ9NlA5W1WOgE51Z1sjFkMdBeRDnW9VimlVOPzJtCvAHqISFcRCQamAfMqnyAi6eKa7S8iQ4Fg4JA31yqllGpatZa9M8aUicjdwELsFMnZxpiNIjLT9fos4DvALSJSCpwCrncNznq8ton+FqWUUh7ogimllPIDDZ1eqZRSqhVrkT16EckHdtfz8g7AwUZsTmul74Ol74Ol74Plz+9DF2OMxymLLTLQN4SIZFT39aUt0ffB0vfB0vfBaqvvg6ZulFLKz2mgV0opP+ePgf5pXzeghdD3wdL3wdL3wWqT74Pf5eiVUkqdyR979EoppSrRQK+UUn7ObwK9iEwUkS0ikiUiD/i6Pc1JRGaLSJ6IbKh0LFZEPhGRba7HGF+2sTmISKqIfC4imSKyUUR+7Drept4LEQkVkW9FZK3rffiD63ibeh/cRMQhIqtF5APX8zb3PvhFoHftZPUEcBnQF5guIn1926pm9TwwscqxB4DPjDE9gM9cz/1dGXC/MaYPcA5wl+u/g7b2XhQDFxljBgGDgYkicg5t731w+zGQWel5m3sf/CLQ08Z3snKVhj5c5fBk4AXXzy9g9wnwa8aY/caYVa6fT2D/z51CG3svjFXgehrk+mdoY+8DgIh0Aq4Anq10uM29D/4S6L3eyaoN6WiM2Q82AAIJPm5PsxKRNGAIsJw2+F640hVrgDzgE2NMm3wfgH8DPweclY61uffBXwK91ztZKf/n2qz+beBeY8xxX7fHF4wx5caYwdjNfkaKSH9ft6m5iciVQJ4xZqWv2+Jr/hLodSersx0QkSQA12Oej9vTLEQkCBvkXzHGvOM63CbfCwBjzFHgC+wYTlt7H0YDV4nILmw69yIReZm29z74TaDXnazONg/4ruvn7wJzfdiWZuHa5ex/QKYx5p+VXmpT74WIxItItOvnMGA8sJk29j4YY35pjOlkoyAcrwAAAKdJREFUjEnDxoRFxpibaGPvA/jRylgRuRybj3PvZPUXHzep2YjIa8BYbAnWA8DvgPeAN4DOwB5gqjGm6oCtXxGR84ElwHoqcrK/wubp28x7ISIDsYOMDmxn7g1jzB9FJI429D5UJiJjgZ8aY65si++D3wR6pZRSnvlL6kYppVQ1NNArpZSf00CvlFJ+TgO9Ukr5OQ30Sinl5zTQK6WUn9NAr5RSfu7/AXQHY8oQdRkpAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# plot losses\n",
     "plt.plot(clf.history['train']['loss'])\n",
@@ -223,9 +539,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1d2063dae48>]"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAD7CAYAAABkO19ZAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3dd5ycV33v8c9vZnvvq7qqa1lykWxkuRdsMDbYGFMudhJCHIgxgWAu1UnIvQlcAlxIKMGJ40uMgQRMtZHBwTY2RgJXCUtWscpqVXa1q+29zs6c+8cZSaPdlTSSVzvSM9/36zWvZ2ae55k580j7nTPnnOc85pxDRESCK5TqAoiIyKmloBcRCTgFvYhIwCnoRUQCTkEvIhJwCnoRkYBLKujN7AYz225mdWZ2zyTrS83sYTN7xcxeNLNzE9btMbNNZrbBzNZNZeFFROT47Hjj6M0sDOwA3gg0Ai8BtzvntiZs82Wg3zn3D2Z2NnCvc+66+Lo9wErnXPup+QgiInIsGUlsswqoc87VA5jZQ8AtwNaEbZYBXwBwzm0zs/lmVu2cazmZQlVUVLj58+efzK4iImlp/fr17c65ysnWJRP0s4GGhMeNwMXjttkIvB34nZmtAuYBc4AWwAFPmJkD/t05d//x3nD+/PmsW6dWHhGRZJnZ3qOtSybobZLnxrf3fBH4upltADYBLwNj8XWXO+eazKwKeNLMtjnn1kxSyDuBOwFqamqSKJaIiCQjmc7YRmBuwuM5QFPiBs65XufcHc65FcCfApXA7vi6pviyFXgY3xQ0gXPufufcSufcysrKSX99iIjISUgm6F8Cas1sgZllAbcBqxM3MLOS+DqA9wNrnHO9ZpZvZoXxbfKB64HNU1d8ERE5nuM23Tjnxszsw8DjQBh4wDm3xczuiq+/D1gKfNfMovhO2vfFd68GHjazg+/1fefcr6b+Y4iIyNEcd3hlKqxcudKpM1ZEJHlmtt45t3KydTozVkQk4BT0IiIBl8zwShGRQIrFHHVt/azb00X30ChVhTlUFWZTVZRNdWEOJXmZxPsYk9Y9OMoz29sIh4xLFpZTWZid1H5dA6M0dg1x3pzik/kox6SgFwmAhs5Bvv/iPqIxR3FuJqV5WZTmZVKSl0VpfiZleVmU5WeRET75H/GxmGNHax/P7+qgczDCkupClswoZH55XlKvG405wqETC82pNjQaZWNjN+v3drFuTyd/2NdNz1DkqNtnhUNUFmazdGYRF9SUcGFNKcvnFpOXdWR07u8e4sktB3h8Swsv7ukkGjvc97m4qoBLF5Zz6aJyLllYTll+FsORKFube9mwr5uNjd1saOhmb8cgFQVZvPS3bzjhL5fjUdCLnMEaOgf512fq+PG6RgDCIWNkLDbptmZQnp9NZWH8VuBrrhUF2VQUZFGen01FoV+W5mUSMmN7Sx/P13fwQn0nL+zuoGswcui1Do7jyMoIUVtVwJIZhSypLiTqHK29I7T1j9DWO0Jr3zBtfSMMRqLMKc1lYUUBCyvzWVhZwKKKfBZVFWAG+zoG2dc5yN6OQRo6B9nbOUhT9xAAmeEQmWEjMxwiOyNEZjhEXnYGc0tzqSnLo6Ysj7lledSU51GUk0kkGmNP+wA7WvrZ0dLHztY+drT0s6d9gLF4CC+uKuDGc2fwunmlvG5eKdVFObT1jdDa58vcEi/7gZ5hNu3v4devthw6xkuqC7lwXglleVk8vb2Vzft7AaitKuCuqxfyxmUzAHhuVwfP1Xfw0z808r3n/YmrNWV5NPcMEYn6cswoymH53GJuu6iG5XOLcc4f36mkUTcip0hb3wgbG7pp7RthZnEOs0pymVWSQ2FO5oRthyNRGruGaOj0YdfRP8LCygKWzSpiYUX+hBpzQ+cg9/6mjp+sbyRkxu2r5vLBaxYzoziH4UiUrsFRugYidA+O0j0UoWNglLa+kYSbD9+2/pFDgZPIDLIzQgxH/JfG3LJcLl7ga6QXLyijsjCbutZ+th/oY9uBXrYd6GP7gT5a+0YAKMjOoKrw8JdKVWEOeVlh9nYOUt/WT33bAEOR6KTHzQxmFuVQU57H7JI8wiGIRB2jYzFGozEi8VvPUISGzqEJNfLi3EwGR8cOfS4zmFeWR221/yI6WDMvzc+a7O2PqmtglA0N3by8r4s/7PO18IHRMS6YW8L158zg+mXVLKwsmHTfSDTGK43dPF/fyabGHuZX5LNibgkr5pYwozjnhMpxNMcadaOgl0DqG47wz0/uoK61nzcsrebG82ZQVXj0P6ixaIzn6jt4dGMTm/b3snRGIStqSrhgbilnzywk8zhNE0OjUTY39bBhXzcbGrvZsK+b/fHa6HiFORnMLsllZnEOAyNR9nUOcqB3+KivnZ0RYsmMQs6ZVcTSmUVsber1AR8y/mhVDXddveikw8I5R+/QGO0DI7T3jdAxMEpH/wjt/aP0DY9xzqwiLl5YxpzSvKRer2cwQmaGTWjaGC8WcxzoHaa+bYD69n6cg5pyXzOfU5pLdkY46c/gA3/w0JdkQ9cghTmZnFVdQG1VIYurCsjJTP71khWNOQZHxyb94k4FBb2klV9vbeEzj2ympW+YmrI89nYMEjK4eEE5Ny2fyQ3nzKC8IJtYzPHink5+8UoT/73pAB0DoxRkZ7BibgnbW/poi9dOszNCnDe7mBVzSyjJy6S9f5S2fh+M7fFQTKxVzi7JZUVNCSvmlLCipoRZJbkc6BmmqXvo0G1/9zDNPUPkZ2X4JoeyPOaV5x26X5KXSX3bAFube9ja1MvW5l62NPXSPRghKyP0mgNegkdBLyk3HIkeav/s6B8hZEZuVpiczBA5mWFyMsPkZoYpzs0kP/vkuo7a+kb4+0e38MtXmllSXcgX33EeF9SUsv1AH798pYlfvNJMffsA4ZCxcl4pezoGaOkdITczzHVLq7h5+SyuPquSnMwwzjmaeoZ5eV8XG/Z183JDN5v39zAyFqMwJ4PKgnjbdmEWFQW+vXvpzCKWzy1JepTFiXLO0dwzTE5mmLITbHaQ4FPQy7RxzrF5fy+rN+5n8/7eQx1xvcNjx98ZCBksn1vClbWVXFlbwYq5JcdtNnHO8ZP1jfyfX77K0GiUv7p2MR+4ehFZGaEJ221t7uWXrzTz9LZWasryuHn5LK5bWnXcpgbw7azRmDslzQAir5WCXl6TAz2+/biqMJvQUYbH1bf1s3pjE6s3NFHfPkBm2DhvdjHVRQfHJedQWZBNZZGv/cacYzgSYygSZTjh1tg1xO/q2tnY0E3M+U69SxeVc2VtBdVFOQyOjjEwEj1i+UpjDy/s7uSi+aV84e3ns7hq8g4xkSA7VtBreKVMcLDm+8SWFp7Y2sKrzX7oWGbYmFWSy+z4bU5pHhlh41ebD7Bpfw9mcMmCcu68aiE3nDuDkryTa174+PVL6BmM8Fx9O2t2trN2ZxtPbp38YmV5WWFK87L43NvO5Y9X1Rz1i0gknalGn0b6hiOs3thELObIz84gPzuDgkPLMK29IzyxtYUnt7awv3sIM7hoXhlvWOabNhq7htjfPURj1yD7u4YODaU7f04xb10+i5vOn3XKOgf3dQzSOxyJlztMflYGuZnhMzfYnYOmlyG7CMoXTf3AaUk7qtGnuWjM8eN1DXzlie20948ec9vsjBBX1lZy93W1XLu0ioqCo3csDkeiDIyMUX6MbaZKTXlyw/umXXQM1n8bXvoWVNTC2TdB7fWQVzb59p31sPGH8MpD0LXHP1c4CxZcFb9dCSVpdIU156CnAcZGoXQ+hBVJp4KOasA9u6udz/3iVV5t7mXlvFLu/9OVzC3NY2BkjP6RMQZGxhgYHaN/JEpeZpjLFpcn1TEJHBotk5acg51PwhOfgfbtMOsCaFwHrz4KFoZ5l8GSN8PZb4acYtjyCGx8CBqeBwwWXg1XfQqio7B7DdT92oc/QOkCmH+Ff82Zy6FqGWRN4xedczDSCwPtHDpN08yX20L+fmYe5JWf+C+RWBRatsC+52Hfc37ZF79gXSjT/7qpqIWKs/ytbCGMDviyDLRCf+vh+6EMOPst/pZbeuz3HeyE7f/tj/VwD4z2x28DMBJfhsJQNAsKZ/rlwfvFs2HORf7f8bUaHYTeJsivgNyS1/56SVLTTUDt7RjgHx97lce3tDC7JJe/fvPZvOW8mVM+h8a0iUZgqAtiY/5+bOzwzTkonHFywXMyWrbA438L9b+BskVw/ed8qDsHzS/Dtsdg+2PQutVvH8rw5axYAituh/P+hw+PRM5B66s+iHavgb2/h+Fuv85CPvRmnA8zz/efc6AdBtoOLwfbfZgVzogH5RK/T+VZUDLPh5hz/hj2NcdvB+LLFug/EF/Gb2NHP4HrkHA2FM2EotkJwTjL/xuMDkBkECJDh+/3t/ovw9E+v3/RbKi5BGou9V8cHTuhfSe07/C/fGKTjNQKZUJ+JRRUwmAX9Ozzzy2+Ds55Oyy5EXKK/La9zbDtF/7Ld8/vwEWhoNrfsgogKx+y48usAv+l29vsv3h6m/2XSeL7LrwGlt7sv1jyK45+XKIR6NgFHXXQucvf76z3y76Eq7DmFPt/m5Ia/2vm4PKsNx3/2E9Co27SyP7uIb61tp7/fH4vmeEQH3r9Yt53xYIzu+bd8CL8+M+gd/+xt8vMg+I5UDwXSub6ZeEM/0ecXQBZhfFlAWQXQk4JhJKc5GtsFLr3wnPfhD9817etX3MPrHwfZByl07mz3tci+1vhnLfBzBXJfxE5B9374MAr0PzK4WViUISzfejlV/hlbqkP7rbtR4bUwe0G2iA6MvG9ckr8cSqogoL4snCG38fC4GKA80sXX472+5rpodt+/97RxKbBeM0/Kw8yc335Zq/0wV5zif83OppoBDp3Q9duH8T5VT7cc0oOH0PnYP8fYMvP/C+m3kb/WRdf578AG1/025XXwrK3+pA+kX+DsVH/Bdi1B3Y+4b8wuvb4L955l/vXm7PSP9e2Hdq2+WVH3ZFfUnkV/pdJ+SJfMSie7f8tuvdB116/7N4HY0P+S+gTO5Ir3zgK+jTwanMv96+p59GNTTjgHRfO5hPXL6GqKMnO0Y5dvkaZVx4Pj/Ij/6imUjTia7nHe23n4MX74fG/8QF+yV9COAvCmb6GFQr7+875kOlu8DW87gbf7jvYcezXD2X6QCuc6WumhbP8MrvIh1d3wh9hbxPgfLlX3QlXffLo7fCn0kC7b3ooqPJfWEc7hkNdvnbctt3XkAfa4gE+8/BnLpzhgz1zijrQYzEY6sQHfK6/TdcvyFgMGl+CLQ/7WnxuaTzc3wqVS6bmPZyDls0+8F999PAvNvDhX7oAKs/271e1FMoX+4BPponGucO/0KqXnVTxFPQB5Zzj2V0d/PuaetbsaCM/K8xtq2r48ysWMLsk9/gv0NsEm38Gm34MzRsmrg9lHg7+4tn+Z2XirWTeibUdRyOw9p9gzZd9u/OVH/d/iJPVqkcHYPVHYPNP4Kwb4Nb7jt8OO9lrDLTF22D748s+vxzp87XexJ/qfc1+O/B/uEVz/M/pxNu8S/0fr0h7HbRu8bX08sVT94V5kjTqJiCGRqPsautnZ2sfO1v6WbOzjc37e6kszOaTb1rCn1w8j+K840ywNNgJr66GTT/x7ZY4/3P2+s/7EBvq9jXhgbYj24B7Gv32B4PwoOK5cNH7/S37GCcqtW6DR+7yQwqXvMX/zP3xe3078hUfg/Pe6Wvn4GuiP3yP7+S89u/8+mSbWBJl5fvbiRju9R2RBdWHyyMymYrF/nYGUI3+NDUyFmX93i6erevg1eZedrb209A1eGgO8MywsWRGIe+5ZB5vu2D2xNn+YlHfdtiyGVq2+ppHy1bfbozzNZDz3gXnvjP5/6zO+S+Krj2+7bRrjw//+t/4mv9lH5kY+LEYPP+v8NRn/fM3fRWW3eLLt+VhWPvPvmwlNXD5R30H1aN3Q0Y2vOM/YNHrX/vBFEkDaro5Azjn2NXWz5od/kzQ5+s7GYpEyQgZiyoLqI1PuXpWtb8/rzx/8jlgBtrhlx+DHU/4zh0AzDc3VC+D6nN9U8jM5VPXftrwEvz2i36IYF45XPZXcNFf+F8CP/+QH0Gy5C1w89d8O/GRHxx2/ArWfAX2x//N51wE73rQt8uLSFIU9KexWMxx/9p6vvPsHprjc8osqMjnytoKrqyt5NJF5RQkO5vj7rXws7/wTS8XvteHefU5voNoOsZhJwZ+bpkfgWEhuPFLsPz2Y3+xOAe7f+uHLl70F0cfySIik1LQn6Z6BiN87EcbeGpbK1fWVnDjuTO5sraCuWUnGMrRMfjtl3wnZ/kieOe3/XjrVGlc55tkQiF40xeOPYxORKaEOmNPQ5v39/DB/1rPgZ5hPnvLObznknkndzJTTyP89P3+LMPlfwRv/vKxO0Wnw5yVcPv3U1sGETlEQZ8CP3xpH3/38y2U52fxww9cyoU1Jzhs8KBtv4RH/tKfnHHr/bD83VNbUBEJBAX9NBqORPlfP9/Mj9Y1cmVtBV9794pjTwg20gd7n/VnzyWest7f4pdDXb4d/p3f9k02IiKTUNCfYrGYY2drPy/s7uAHLzbwanMvH7l2MXe/4SzC46fYjcX8iUu7nva3hhcOn0odyvBnMRbO8CNo5l3mT+1eeYcfiigichQK+ikWjTm2NvXywu4OXtjdyUt7Ouke9BeOnl2SywN/tpJrz65O2CHiJ8DautqPRz942v6M8/0wxUXX+rNIc8tO7qQhEUl7Cvop1DUwyrvvf44dLf7s0XnleVy/rJpVC8q5eEEZc0pzD3e4du+D9d+Bl7/nm2LyK2HxG/2ETAuvmTjeXETkJCUV9GZ2A/B1IAx8yzn3xXHrS4EHgEXAMPDnzrnNyewbFCNjUT7wvfXsaR/kS+84j6vPqpp4taXomJ8Fb90Dfqy5mb9IxevugNo3+km6RESm2HGD3szCwL3AG4FG4CUzW+2cS5i6jb8BNjjnbjWzs+PbX5fkvmc85xyf/skrvLink2/cfgFvXT7ryA2GumBd/CpEvfv9zIFXfwoueI/GmIvIKZdMjX4VUOecqwcws4eAW4DEsF4GfAHAObfNzOabWTWwMIl9z3hf/fVOHtnQxCfftOTIkO/cDc//G7z8nxAZ8E0yN/5fPwWBLpkmItMkmbSZDTQkPG4ELh63zUbg7cDvzGwVMA+Yk+S+Z7Sfrm/kG0/t5F2vm8NfXhMf4tjwIjz7L35ebAv7mRkv/RDMOC+1hRWRtJRM0E92uub4eRO+CHzdzDYAm4CXgbEk9/VvYnYncCdATc2ZcXHk53Z1cM/PXuGyReV8/tbzMBeDh94D23/pZ2G8/G5Y9QF/MQsRkRRJJugbgcSG5DlAU+IGzrle4A4A88NKdsdvecfbN+E17gfuBz/XTXLFT5261n4+8L11zCvP59/+5HVkZYTg2W/6kL/6Hj80MtVTEYiIAMkMzH4JqDWzBWaWBdwGrE7cwMxK4usA3g+siYf/cfc9E7X1jXDHgy+SlRHi2392EcW5mdC2A56OXyT6mnsU8iJy2jhujd45N2ZmHwYexw+RfMA5t8XM7oqvvw9YCnzXzKL4jtb3HWvfU/NRpsfz9R189KENdA+N8tCdl/qZJmNReOSD/hqZN31t+q6TKSKShKSGfjjnHgMeG/fcfQn3nwNqk933TDQWjfGNp+v45tM7mVeez7feexnnzi72K5/9F3/RjHf8BxRWH/uFRESmmcb4JaGpe4iPPrSBF/d08vYLZ/PZW849fDGQ1m3wm8/D0pvh3HektqAiIpNQ0B/H41sO8KmfvMJYNMZX372cWy9IuLxddMxf8Dq7EN7yVTXZiMhpSUF/FLGY47O/2MqDz+7hvNnFfOP2C1hQkX/kRr//GjS97K9vWlCZknKKiByPgv4ontrWyoPP7uFPL53HZ96yzA+fTHRgMzzzRTjn7XDOrakppIhIEhT0k3DO8a/P1DGnNJf/ddMyMsLjQj4a8U02uSXw5q+kppAiIknSBOeTeHF3Jy/v6+bOqxZODHmA338dDmyCm74K+eXTX0ARkROgoJ/Ev/12F+X5WbzrdZPMLNndAGu+4kfZLL15+gsnInKCFPTjbG3q5Zntbdxx+XxysyaZH/6Jz/jlm/5xegsmInKSFPTj3PfbXeRnhXnPJfMnrqx/BrY+Ald+DErOjInXREQU9An2dQzyi1ea+ONL5lGcl3nkymgE/vvTUDIPLvtIagooInISNOomwf9bW09GKMT7rlgwceWL90PbNrjtB5CZM3G9iMhpSjX6uLa+EX60roG3Xzib6qJxQd7X4sfML34DLLkxNQUUETlJCvq4B5/dzWg0xp1XLZy48td/D5EhuOFLmuZARM44CnqgbzjCd5/by43nzmBh5bh55BtehI3f95cCrFicmgKKiLwGCnrg+y/so294jLuuXnTkilgUHvsEFM6Eqz6ZmsKJiLxGad8ZOxyJ8q3f7eaKxRWcP6fkyJV/+C40b/TzzOuKUSJyhkr7Gv3DL++nrW+ED14zrjY/OgBPfRbmXa555kXkjKagf3k/Z88o5LJF4+as2fscDHXClR9XB6yInNHSOuidc+xo6eOCmlJsfJjv/i2EMqHm0tQUTkRkiqR10Lf3j9I9GKG2apL29z1rYc5FkJU3/QUTEZlCaR30O1v6AKitHhf0Q92+E3bBVSkolYjI1ErvoG/tB+Cs6sIjV+x9FlwMFlyZglKJiEyttA76HS19FOZkUFWYfeSKPWshI8c33YiInOHSOuh3tvZzVnXhJB2xa2HuKsjInnxHEZEzSFoHfV1r/8SO2MFOaNmk9nkRCYy0Dfr2/hE6B0apHd8+v2etX85X0ItIMKRt0O9s8R2xE2r0u9dCZj7MvjAFpRIRmXrpG/StRxlauWctzLsUwpmT7CUicuZJ36Bv6acwO4MZiRcZ6WvxV5Gar2GVIhIcaRv0O1r6WFxdcOSIm4Pt8xo/LyIBkrZBX9faz1lVk3TEZhfBjOWpKZSIyCmQVNCb2Q1mtt3M6szsnknWF5vZo2a20cy2mNkdCev2mNkmM9tgZuumsvAnq6N/hI6B0Ynt87vX+mmJw2k/Tb+IBMhxg97MwsC9wI3AMuB2M1s2brMPAVudc8uBa4B/MrOshPWvd86tcM6tnJpivzYHpz44Ymhlz37o3KVmGxEJnGRq9KuAOudcvXNuFHgIuGXcNg4oNN/gXQB0AmNTWtIpdCjoE4dWHho/r6AXkWBJJuhnAw0JjxvjzyX6JrAUaAI2AXc752LxdQ54wszWm9mdR3sTM7vTzNaZ2bq2trakP8DJ2NnSR0F2BjOLE0bc7F4LuaVQfe4pfW8RkemWTNBPdnklN+7xm4ANwCxgBfBNMyuKr7vcOXchvunnQ2Y26Smnzrn7nXMrnXMrKysrkyv9SdrZ0s/iqnEjbnavgflXQCht+6dFJKCSSbVGYG7C4zn4mnuiO4CfOa8O2A2cDeCca4ovW4GH8U1BKbWzte/IZpuuPdCzT9MeiEggJRP0LwG1ZrYg3sF6G7B63Db7gOsAzKwaWALUm1m+mRXGn88Hrgc2T1XhT0bnwCjt/aNHzkG/W+PnRSS4jjuO0Dk3ZmYfBh4HwsADzrktZnZXfP19wOeAB81sE76p59POuXYzWwg8HG8iyQC+75z71Sn6LEk5eFWpxdXjOmLzK6Hy7BSVSkTk1ElqwLhz7jHgsXHP3ZdwvwlfWx+/Xz1wWp19NOGqUs7F2+evhPHz0ouIBEDa9TzWtfaTnxVm1sERNx27oK9ZzTYiElhpF/R+jpuEq0rtWeOX6ogVkYBKu6DfOf6qUrvXQOEsKF+UukKJiJxCaRX03YOjtPWNHA76WBTqn4GFV6t9XkQCK62CfkJHbPNGGOqCRdelsFQiIqdWWgX9joNDKw/W6Hc95ZcLr0lJeUREpkNaBf3Oln7yssLMLsn1T+z6Dcw4HwpO7ZQLIiKplFZBX9fq57gJhQxG+qDhBVisZhsRCba0CvodLX3UHryq1O61EBuDRdemtlAiIqdY2gR9z2CE1r6Rw1eV2vU0ZObB3ItTWzARkVMsbYJ+Z6vviD0rMejnXwkZ2SkslYjIqZdGQX/wqlKFflrizl1qthGRtJA2Qb+jpY/czPiIm11P+yfVESsiaSBtgv6IETe7nobiuVC+ONXFEhE55dIm6He2xOe4iY5B/RpY9HpNeyAiaSEtgr5nKMKB3mFqqwth/3oY6dG0ByKSNtIi6OsOdcQW+GYbC8ECTUssIukhLYK+oXMQgPkV+T7oZ10IeWUpLpWIyPRIi6DvGYoAUBYagP3rNNpGRNJKWgR9bzzoC5ufAxfT+HkRSSvpEfTDEXIzw2Tu+Q1kF8Hs16W6SCIi0yYtgr5nKEJRThjqnvadsOHMVBdJRGTapEXQ9w6NsTSrDXr2qdlGRNJOegT9cIQrQq/4Bwp6EUkzaRP0K8dehrKFULYg1cUREZlWaRH0g4NDLB3eoNq8iKSltAj6+cNbyXbDCnoRSUuBD/pYzDFjdJ9/MHNFagsjIpICgQ/6gdExKujxDwqqUlsYEZEUCHzQ9w6PUWVdDGeVavy8iKSlpILezG4ws+1mVmdm90yyvtjMHjWzjWa2xczuSHbfU613KEKl9TCaUzndby0iclo4btCbWRi4F7gRWAbcbmbLxm32IWCrc245cA3wT2aWleS+p1TvUIQq6yaar2YbEUlPydToVwF1zrl659wo8BBwy7htHFBoZgYUAJ3AWJL7nlI9QxEqrRsKqqfzbUVEThvJBP1soCHhcWP8uUTfBJYCTcAm4G7nXCzJfU+p3qEIlXQTKlTQi0h6SiboJ7uwqhv3+E3ABmAWsAL4ppkVJbmvfxOzO81snZmta2trS6JYyRnu6yTbxsgqmTllrykiciZJJugbgbkJj+fga+6J7gB+5rw6YDdwdpL7AuCcu985t9I5t7Kycuo6TmN9zQBkFSvoRSQ9JRP0LwG1ZrbAzLKA24DV47bZB1wHYGbVwBKgPsl9T62+VgDCCnoRSVMZx9vAOTdmZh8GHgfCwAPOuS1mdld8/X3A54AHzWwTvrnm0865doDJ9j01H2Vy4cEWf0edsSKSpo4b9ADOuceAx8QKQLgAAAo5SURBVMY9d1/C/Sbg+mT3nU6ZQ/H2fp0VKyJpKvBnxuaMtDNCtr+EoIhIGgp80BdEOujNKAObbACQiEjwBT7oC8c66c8sT3UxRERSJvBBXxrtZCi7ItXFEBFJmUAHfTTmKKdbE5qJSFoLdND39w9Qav2M5SnoRSR9BTroB7r8SbhOY+hFJI0FOuiHOn3Qh4pmpLgkIiKpE+igH+3x89xkFmn6AxFJX4EO+ljPAQCyS1WjF5H0Feigp7+FmDPySlWjF5H0FeigDw200kEhxQW5qS6KiEjKBDroM4faaHclFGQlNXebiEggBTroc0ba6QyVEgppnhsRSV+BDvr80XZ6wmWpLoaISEoFN+id04RmIiIEOeiHushgjKEsTWgmIuktuEHf7y8hOJKreW5EJL0FN+j7/MlSYwp6EUlzwQ36/lZAE5qJiAQ26KO9fp4bK9D0ByKS3gJ7JtFozwGcyya3QBcFF5H0Ftigj/Y00+5KKM7LSnVRRERSKrBNN/S30EYxRTmZqS6JiEhKBTboQwNttLoSinIV9CKS3gIb9JlDrbS5EopyA9s6JSKSlGAGfWSYzEivr9Gr6UZE0lwwgz5+VmwbJRSr6UZE0lxAg96fLNVBKXlZ4RQXRkQktQIa9H76g8Gscsw0F72IpLekgt7MbjCz7WZWZ2b3TLL+k2a2IX7bbGZRMyuLr9tjZpvi69ZN9QeY1MEJzXI0c6WIyHGHpJhZGLgXeCPQCLxkZqudc1sPbuOc+zLw5fj2NwP/0znXmfAyr3fOtU9pyY+lr4UYIWK5CnoRkWRq9KuAOudcvXNuFHgIuOUY298O/GAqCnfS+lvoCRVTkJed0mKIiJwOkgn62UBDwuPG+HMTmFkecAPw04SnHfCEma03sztPtqAnpL+FDo24EREBkpvrZrLeTHeUbW8Gfj+u2eZy51yTmVUBT5rZNufcmglv4r8E7gSoqalJoljH0N+iMfQiInHJ1OgbgbkJj+cATUfZ9jbGNds455riy1bgYXxT0ATOufudcyudcysrK1/jxUL6W2mOFmv6AxERkgv6l4BaM1tgZln4MF89fiMzKwauBn6e8Fy+mRUevA9cD2yeioIfVSyG62/hQKyIohxNfyAictwkdM6NmdmHgceBMPCAc26Lmd0VX39ffNNbgSeccwMJu1cDD8fHsmcA33fO/WoqP8AEQ11YbIxWV8oi1ehFRJKbj9459xjw2Ljn7hv3+EHgwXHP1QPLX1MJT1T8ZKk2V8yFCnoRkQCeGXtwnht1xoqIAEEM+j4f9K1oimIREQhi0KtGLyJyhEAGfSScxyA5Gl4pIkJAg34gqxxAZ8aKiBDEoO9roS+jnKxwiOyM4H08EZETFbwk7G+hO1RKUW6G5qIXESGgQd9upeqIFRGJC1bQjw7CSC9trphCtc+LiABBC/oBf63Y5liJ5rkREYkLVtDHT5ZqihRpxI2ISFywgj5+slRDpEBj6EVE4gIZ9PXDBeqMFRGJC1zQOwvRGi3UPDciInHBCvq+A8TyKokRUo1eRCQuWEHf30ok11+GUJ2xIiJewIL+ACM5PujVGSsi4gUs6FsZyPQTmmkcvYiIF5ygdw5iUfoOBr1q9CIiQJCC3gw+uZMX5n8QQJ2xIiJxwQn6uN7hMQANrxQRiQtk0OdkhsjOCKe6KCIip4XABX3PYETNNiIiCQIX9L3DEXXEiogkCGbQa2iliMghwQv6oTHV6EVEEgQv6Icjmv5ARCRB8IJ+SJ2xIiKJAhX0zjl6h8c0hl5EJEGggn5gNEo05lSjFxFJkFTQm9kNZrbdzOrM7J5J1n/SzDbEb5vNLGpmZcnsO5V6hyKA5rkREUl03KA3szBwL3AjsAy43cyWJW7jnPuyc26Fc24F8NfAb51zncnsO5V6h33QqzNWROSwZGr0q4A651y9c24UeAi45Rjb3w784CT3fU16h+Lz3KjpRkTkkGSCfjbQkPC4Mf7cBGaWB9wA/PRE950KPYeabtQZKyJyUDJBb5M8546y7c3A751znSe6r5ndaWbrzGxdW1tbEsWa6FAbvWr0IiKHJBP0jcDchMdzgKajbHsbh5ttTmhf59z9zrmVzrmVlZWVSRRrooNt9OqMFRE5LJmgfwmoNbMFZpaFD/PV4zcys2LgauDnJ7rvVDncRq+mGxGRg46biM65MTP7MPA4EAYecM5tMbO74uvvi296K/CEc27gePtO9Yc4qHc4Qn5WmIxwoE4PEBF5TZKq+jrnHgMeG/fcfeMePwg8mMy+p0rPkKYoFhEZL1BVX81zIyIyUbCCfjiioZUiIuMEK+iHxlSjFxEZJ1hBr7noRUQmCFTQqzNWRGSiwAS9c47rzq7i/DnFqS6KiMhpJTA9l2bG1267INXFEBE57QSmRi8iIpNT0IuIBJyCXkQk4BT0IiIBp6AXEQk4Bb2ISMAp6EVEAk5BLyIScObc0S7/mjpm1gbsPcndK4D2KSzOmUrHwdNx8HQcvCAfh3nOuUmvw3paBv1rYWbrnHMrU12OVNNx8HQcPB0HL12Pg5puREQCTkEvIhJwQQz6+1NdgNOEjoOn4+DpOHhpeRwC10YvIiJHCmKNXkREEgQm6M3sBjPbbmZ1ZnZPqssznczsATNrNbPNCc+VmdmTZrYzvixNZRmng5nNNbPfmNmrZrbFzO6OP59Wx8LMcszsRTPbGD8O/xB/Pq2Ow0FmFjazl83sF/HHaXccAhH0ZhYG7gVuBJYBt5vZstSWalo9CNww7rl7gKecc7XAU/HHQTcGfNw5txS4BPhQ/P9Buh2LEeBa59xyYAVwg5ldQvodh4PuBl5NeJx2xyEQQQ+sAuqcc/XOuVHgIeCWFJdp2jjn1gCd456+BfhO/P53gLdNa6FSwDnX7Jz7Q/x+H/6PezZpdiyc1x9/mBm/OdLsOACY2RzgLcC3Ep5Ou+MQlKCfDTQkPG6MP5fOqp1zzeADEKhKcXmmlZnNBy4AXiANj0W8uWID0Ao86ZxLy+MAfA34FBBLeC7tjkNQgt4meU7DidKUmRUAPwU+6pzrTXV5UsE5F3XOrQDmAKvM7NxUl2m6mdlNQKtzbn2qy5JqQQn6RmBuwuM5QFOKynK6aDGzmQDxZWuKyzMtzCwTH/L/5Zz7WfzptDwWAM65buAZfB9Ouh2Hy4G3mtkefHPutWb2n6TfcQhM0L8E1JrZAjPLAm4DVqe4TKm2Gnhv/P57gZ+nsCzTwswM+A/gVefcPyesSqtjYWaVZlYSv58LvAHYRpodB+fcXzvn5jjn5uMz4Wnn3J+QZscBAnTClJm9Gd8eFwYecM59PsVFmjZm9gPgGvzMfC3A/wYeAX4E1AD7gHc558Z32AaKmV0BrAU2cbhN9m/w7fRpcyzM7Hx8J2MYX5n7kXPus2ZWThodh0Rmdg3wCefcTel4HAIT9CIiMrmgNN2IiMhRKOhFRAJOQS8iEnAKehGRgFPQi4gEnIJeRCTgFPQiIgGnoBcRCbj/D9+R5gK/wIc7AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# plot auc\n",
     "plt.plot([-x for x in clf.history['train']['metric']])\n",
@@ -234,9 +573,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[<matplotlib.lines.Line2D at 0x1d22dae6f48>]"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY0AAAD4CAYAAAAQP7oXAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAZtklEQVR4nO3dfYxd9YHe8e+DeUkkgpyUIXJtp/ZqJ4ihNAauvK4oUYSaxGZJTIvQ2qLYSpC8DkYCLU1roqDVrlQp+w+qLBEQ73gXsKxCitM4a1EKS7UyhOvg9UuMw9jJhsEWnhQVXGWF5eTpH+c35XC56/nNYM/UnucjXd1zfm/nd84f8/i8XB/ZJiIiosZZ0z2BiIg4fSQ0IiKiWkIjIiKqJTQiIqJaQiMiIqqdPd0TONUuvPBCL1iwYLqnERFxWtmxY8evbQ/0lp/xobFgwQK63e50TyMi4rQi6e/7lefyVEREVEtoREREtYRGRERUS2hERES1hEZERFSrCg1JSyXtlzQsaX2feknaUOp3SbqilM+X9IKkfZL2Srq91efGUvY7SZ2e8e4qY+2X9NVW+ZWSdpe6DZI0+V2PiIiJGjc0JM0C7gWWAUPASklDPc2WAYPlswa4r5QfB+60fQmwBFjX6rsH+LfASz3bGwJWAJcCS4HvlzlQxl3T2tbS6j2NiIiPreZMYzEwbPug7WPAJmB5T5vlwEY3XgZmS5pj+7DtnwLYPgrsA+aW9X229/fZ3nJgk+33bf8CGAYWS5oDXGB7u5v/z30jcP3EdzkiIiarJjTmAm+21kdK2YTaSFoAXA68MsntzS3LJ5rH2LbWSOpK6o6Ojo6zuYiIqFUTGv3uG/S+uemEbSSdDzwN3GH7vUlur2YeTaH9gO2O7c7AwEd+BR8REZNUExojwPzW+jzgUG0bSefQBMYTtp/5GNsbKcsnmkdERJxCNaHxKjAoaaGkc2luUm/pabMFWFWeoloCvGv7cHm66WFgn+17Kue0BVgh6TxJC2lueP/E9mHgqKQlZdxVwLOVY0ZExEkwbmjYPg7cBmyjuZG92fZeSWslrS3NtgIHaW5aPwjcWsqvAm4GrpG0s3yuBZD0bySNAP8S+JGkbWV7e4HNwM+AvwbW2f5tGe9bwENlOweAH3+svY+IiAlR8yDSmavT6Tj/y21ExMRI2mG701ueX4RHRES1hEZERFRLaERERLWERkREVEtoREREtYRGRERUS2hERES1hEZERFRLaERERLWERkREVEtoREREtYRGRERUS2hERES1hEZERFRLaERERLWERkREVKsKDUlLJe2XNCxpfZ96SdpQ6ndJuqKUz5f0gqR9kvZKur3V5zOSnpP0Rvn+dCm/qfWWv52SfidpUal7scxjrO6ik3MYIiKixrihIWkWcC+wDBgCVkoa6mm2jOZd3oPAGuC+Un4cuNP2JcASYF2r73rgeduDwPNlHdtP2F5kexHNq2J/aXtna1s3jdXbPjLxXY6IiMmqOdNYDAzbPmj7GLAJWN7TZjmw0Y2XgdmS5tg+bPunALaP0rxjfG6rz+Nl+XHg+j7bXgk8NaE9ioiIU6YmNOYCb7bWR/jgD391G0kLgMuBV0rRZ20fBijf/S41/REfDY1Hy6WpuyWp34QlrZHUldQdHR39x/YrIiImqCY0+v1h9kTaSDofeBq4w/Z7NROT9AfAb2zvaRXfZPsy4OryublfX9sP2O7Y7gwMDNRsLiIiKtSExggwv7U+DzhU20bSOTSB8YTtZ1pt3pY0p7SZA/Ten1hBz1mG7bfK91HgSZpLZxERMUVqQuNVYFDSQknn0vwx39LTZguwqjxFtQR41/bhcvnoYWCf7Xv69FldllcDz45VSDoLuJHm/slY2dmSLizL5wDXAe2zkIiIOMXOHq+B7eOSbgO2AbOAR2zvlbS21N8PbAWuBYaB3wDfKN2vormEtFvS2BNQ37G9FfgesFnSLcCvaEJizBeBEdsHW2XnAdtKYMwC/jvw4CT2OSIiJkl27+2JM0un03G3253uaUREnFYk7bDd6S3PL8IjIqJaQiMiIqolNCIiolpCIyIiqiU0IiKiWkIjIiKqJTQiIqJaQiMiIqolNCIiolpCIyIiqiU0IiKiWkIjIiKqJTQiIqJaQiMiIqolNCIiolpCIyIiqlWFhqSlkvZLGpa0vk+9JG0o9bskXVHK50t6QdI+SXsl3d7q8xlJz0l6o3x/upQvkPQPknaWz/2tPldK2l22s6G8TjYiIqbIuKEhaRZwL7AMGAJWShrqabYMGCyfNcB9pfw4cKftS4AlwLpW3/XA87YHgefL+pgDtheVz9pW+X1l/LFtLa3e04iI+NhqzjQWA8O2D9o+BmwClve0WQ5sdONlYLakObYP2/4pgO2jwD5gbqvP42X5ceD6E01C0hzgAtvb3byjduN4fSIi4uSqCY25wJut9RE++MNf3UbSAuBy4JVS9FnbhwHK90Wt5gslvSbpbyRd3drGyDjzGNvWGkldSd3R0dET711ERFSrCY1+9w08kTaSzgeeBu6w/d442zsMfM725cCfAE9KuqByHk2h/YDtju3OwMDAOJuLiIhaNaExAsxvrc8DDtW2kXQOTWA8YfuZVpu3yyWnsUtPRwBsv2/7f5XlHcAB4PNlG/PGmUdERJxCNaHxKjAoaaGkc4EVwJaeNluAVeUpqiXAu7YPl6ebHgb22b6nT5/VZXk18CyApIFy8x1Jv0dzw/tguYR1VNKSMu6qsT4RETE1zh6vge3jkm4DtgGzgEds75W0ttTfD2wFrgWGgd8A3yjdrwJuBnZL2lnKvmN7K/A9YLOkW4BfATeW+i8Cfy7pOPBbYK3td0rdt4DHgE8CPy6fiIiYImoeRDpzdTodd7vd6Z5GRMRpRdIO253e8vwiPCIiqiU0IiKiWkIjIiKqJTQiIqJaQiMiIqolNCIiolpCIyIiqiU0IiKiWkIjIiKqJTQiIqJaQiMiIqolNCIiolpCIyIiqiU0IiKiWkIjIiKqVYWGpKWS9ksalrS+T70kbSj1uyRdUcrnS3pB0j5JeyXd3urzGUnPSXqjfH+6lH9Z0g5Ju8v3Na0+L5Z57Cyfiz7+IYiIiFrjhkZ59eq9wDJgCFgpaain2TKa17IOAmuA+0r5ceBO25cAS4B1rb7rgedtDwLPl3WAXwNfs30ZzWtg/7JnWzfZXlQ+R+p3NSIiPq6aM43FwLDtg7aPAZuA5T1tlgMb3XgZmC1pju3Dtn8KYPsosA+Y2+rzeFl+HLi+tHvN9qFSvhf4hKTzJrl/ERFxEtWExlzgzdb6CB/84a9uI2kBcDnwSin6rO3DAOW736WmG4DXbL/fKnu0XJq6W5L6TVjSGkldSd3R0dET7VtERExATWj0+8Pc+2LxE7aRdD7wNHCH7fdqJibpUuAvgD9uFd9ULltdXT439+tr+wHbHdudgYGBms1FRESFmtAYAea31ucBh2rbSDqHJjCesP1Mq83bkuaUNnOA/3d/QtI84AfAKtsHxsptv1W+jwJP0lw6i4iIKVITGq8Cg5IWSjoXWAFs6WmzBVhVnqJaArxr+3C5fPQwsM/2PX36rC7Lq4FnASTNBn4E3GX7b8caSzpb0oVl+RzgOmDPBPY1IiI+pnFDw/Zx4DZgG82N7M2290paK2ltabYVOAgMAw8Ct5byq2guIV3Tekz22lL3PeDLkt4AvlzWKdv6feDunkdrzwO2SdoF7ATeKtuKiIgpIrv39sSZpdPpuNvtTvc0IiJOK5J22O70lucX4RERUS2hERER1RIaERFRLaERERHVEhoREVEtoREREdUSGhERUS2hERER1RIaERFRLaERERHVEhoREVEtoREREdUSGhERUS2hERER1RIaERFRLaERERHVqkJD0lJJ+yUNS1rfp16SNpT6XZKuKOXzJb0gaZ+kvZJub/X5jKTnJL1Rvj/dqrurjLVf0ldb5VdK2l3qNpTXyUZExBQZNzQkzQLuBZYBQ8BKSUM9zZYBg+WzBrivlB8H7rR9CbAEWNfqux543vYg8HxZp9SvAC4FlgLfL3OgjLumta2lE93hiIiYvLMr2iwGhm0fBJC0CVgO/KzVZjmw0c27Y1+WNFvSHNuHgcMAto9K2gfMLX2XA18q/R8HXgT+YynfZPt94BeShoHFkn4JXGB7e5nHRuB64MeT3PcT+rMf7uVnh947FUNHRJxyQ//0Av70a5ee9HFrLk/NBd5srY+Usgm1kbQAuBx4pRR9toQK5fuiccaaW5ZPNI+xba2R1JXUHR0dPcGuRUTERNScafS7b+CJtJF0PvA0cIft8f75/o+NVTOPptB+AHgAoNPp9G0znlOR0BERp7uaM40RYH5rfR5wqLaNpHNoAuMJ28+02rwtaU5pMwc4Ms5YI2X5RPOIiIhTqCY0XgUGJS2UdC7NTeotPW22AKvKU1RLgHdtHy5PNz0M7LN9T58+q8vyauDZVvkKSedJWkhzw/sn5RLWUUlLyrirWn0iImIKjHt5yvZxSbcB24BZwCO290paW+rvB7YC1wLDwG+Ab5TuVwE3A7sl7Sxl37G9FfgesFnSLcCvgBvLeHslbaa5WX4cWGf7t6Xvt4DHgE/S3AA/JTfBIyKiPzUPPJ25Op2Ou93udE8jIuK0ImmH7U5veX4RHhER1RIaERFRLaERERHVEhoREVEtoREREdUSGhERUS2hERER1RIaERFRLaERERHVEhoREVEtoREREdUSGhERUS2hERER1RIaERFRLaERERHVEhoREVGtKjQkLZW0X9KwpPV96iVpQ6nfJemKVt0jko5I2tPT5wuStkvaLemHki4o5TdJ2tn6/E7SolL3YpnHWN1FH2/3IyJiIsYNDUmzgHuBZcAQsFLSUE+zZTTv8h4E1gD3teoeA5b2GfohYL3ty4AfAN8GsP2E7UW2F9G8KvaXtne2+t00Vm/7SMU+RkTESVJzprEYGLZ90PYxYBOwvKfNcmCjGy8DsyXNAbD9EvBOn3EvBl4qy88BN/RpsxJ4qmKOERExBWpCYy7wZmt9pJRNtE2vPcDXy/KNwPw+bf6Ij4bGo+XS1N2S1G9gSWskdSV1R0dHx5lGRETUqgmNfn+YPYk2vb4JrJO0A/gUcOxDA0p/APzGdvteyE3lctbV5XNzv4FtP2C7Y7szMDAwzjQiIqJWTWiM8OGzgHnAoUm0+RDbr9v+iu0rac4mDvQ0WUHPWYbtt8r3UeBJmktnERExRWpC41VgUNJCSefS/DHf0tNmC7CqPEW1BHjX9uETDTr25JOks4DvAve36s6iuWS1qVV2tqQLy/I5wHU0l7giImKKjBsato8DtwHbgH3AZtt7Ja2VtLY02wocBIaBB4Fbx/pLegrYDlwsaUTSLaVqpaSfA6/TnJU82trsF4ER2wdbZecB2yTtAnYCb5VtRUTEFJE93q2H01un03G3253uaUREnFYk7bDd6S3PL8IjIqJaQiMiIqolNCIiolpCIyIiqiU0IiKiWkIjIiKqJTQiIqJaQiMiIqolNCIiolpCIyIiqiU0IiKiWkIjIiKqJTQiIqJaQiMiIqolNCIiolpVaEhaKmm/pGFJ6/vUS9KGUr9L0hWtukckHZG0p6fPFyRtl7Rb0g8lXVDKF0j6B0k7y6f9Rr8rS/vhsr1+7yaPiIhTZNzQkDQLuBdYBgzRvHFvqKfZMmCwfNYA97XqHgOW9hn6IWC97cuAHwDfbtUdsL2ofNa2yu8r449tq9+4ERFxitScaSwGhm0ftH2M5r3dy3vaLAc2uvEyMFvSHADbLwHv9Bn3YuClsvwccMOJJlHGu8D2djevG9wIXF8x/4iIOElqQmMu8GZrfaSUTbRNrz3A18vyjcD8Vt1CSa9J+htJV7e2MVKzDUlrJHUldUdHR8eZRkRE1KoJjX73DXpfLF7Tptc3gXWSdgCfAo6V8sPA52xfDvwJ8GS531G9DdsP2O7Y7gwMDIwzjYiIqHV2RZsRPnwWMA84NIk2H2L7deArAJI+D/xhKX8feL8s75B0APh82ca8iWwjIiJOrpozjVeBQUkLJZ0LrAC29LTZAqwqT1EtAd61ffhEg0q6qHyfBXwXuL+sD5Sb70j6PZob3gfLeEclLSlPTa0Cnq3d0YiI+PjGDQ3bx4HbgG3APmCz7b2S1koae7JpK3AQGAYeBG4d6y/pKWA7cLGkEUm3lKqVkn4OvE5zxvBoKf8isEvS3wH/BVhre+xG+rdonroaBg4AP57cbkdExGSoeRDpzNXpdNztdqd7GhERpxVJO2x3esvzi/CIiKiW0IiIiGoJjYiIqJbQiIiIagmNiIioltCIiIhqCY2IiKiW0IiIiGoJjYiIqJbQiIiIagmNiIioltCIiIhqCY2IiKiW0IiIiGoJjYiIqJbQiIiIalWhIWmppP2ShiWt71MvSRtK/S5JV7TqHpF0RNKenj5fkLRd0m5JP5R0QSn/sqQdpXyHpGtafV4s89hZPhdNftcjImKixg2N8r7ue4FlwBDNa1qHepoto3mX9yCwBrivVfcYsLTP0A8B621fBvwA+HYp/zXwtVK+GvjLnn432V5UPkfGm39ERJw8NWcai4Fh2wdtHwM2Act72iwHNrrxMjBb0hwA2y8B7/BRFwMvleXngBtK+9dsHyrle4FPSDpvIjsVERGnRk1ozAXebK2PlLKJtum1B/h6Wb4RmN+nzQ3Aa7bfb5U9Wi5N3S1J/QaWtEZSV1J3dHR0nGlEREStmtDo94fZk2jT65vAOkk7gE8Bxz40oHQp8BfAH7eKbyqXra4un5v7DWz7Adsd252BgYFxphEREbVqQmOED58FzAMOTaLNh9h+3fZXbF8JPAUcGKuTNI/mPscq2wdafd4q30eBJ2kunUVExBSpCY1XgUFJCyWdC6wAtvS02QKsKk9RLQHetX34RIOOPfkk6Szgu8D9ZX028CPgLtt/22p/tqQLy/I5wHU0l7giImKKjBsato8DtwHbgH3AZtt7Ja2VtLY02wocBIaBB4Fbx/pLegrYDlwsaUTSLaVqpaSfA6/TnJU8WspvA34fuLvn0drzgG2SdgE7gbfKtiIiYorIHu/Ww+mt0+m42+1O9zQiIk4rknbY7vSW5xfhERFRLaERERHVEhoREVEtoREREdUSGhERUS2hERER1RIaERFRLaERERHVEhoREVEtoREREdUSGhERUS2hERER1RIaERFRLaERERHVEhoREVEtoREREdWqQkPSUkn7JQ1LWt+nXpI2lPpdkq5o1T0i6YikPT19viBpu6Tdkn4o6YJW3V1lrP2Svtoqv7K0Hy7b0+R2OyIiJmPc0JA0C7gXWAYM0bymdain2TJgsHzWAPe16h4DlvYZ+iFgve3LgB8A3y7bG6J5D/mlpd/3yxwo465pbavfuBERcYrUnGksBoZtH7R9DNgELO9psxzY6MbLwGxJcwBsvwS802fci4GXyvJzwA2tsTbZft/2L2jeO764jHeB7e1u3lG7Ebi+ek8jIuJjqwmNucCbrfWRUjbRNr32AF8vyzcC88cZa25ZHncbktZI6krqjo6OjjONiIioVRMa/e4beBJten0TWCdpB/Ap4Ng4Y1Vvw/YDtju2OwMDA+NMIyIiap1d0WaED84CAOYBhybR5kNsvw58BUDS54E/HGeskbJcvY2IiDi5as40XgUGJS2UdC7NTeotPW22AKvKU1RLgHdtHz7RoJIuKt9nAd8F7m+NtULSeZIW0tzw/kkZ76ikJeWpqVXAs3W7GRERJ8O4oWH7OHAbsA3YB2y2vVfSWklrS7OtwEGam9YPAreO9Zf0FLAduFjSiKRbStVKST8HXqc5Y3i0bG8vsBn4GfDXwDrbvy19vkXz1NUwcAD48WR3PCIiJk7Ng0hnrk6n4263O93TiIg4rUjaYbvTW55fhEdERLWERkREVEtoREREtYRGRERUO+NvhEsaBf5+kt0vBH59EqdzuspxaOQ4NHIcPnAmH4t/Zvsjv44+40Pj45DU7ff0wEyT49DIcWjkOHxgJh6LXJ6KiIhqCY2IiKiW0DixB6Z7Av+fyHFo5Dg0chw+MOOORe5pREREtZxpREREtYRGRERUS2j0IWmppP2ShiWtn+75TCVJj0g6ImlPq+wzkp6T9Eb5/vR0znEqSJov6QVJ+yTtlXR7KZ9Rx0LSJyT9RNLflePwZ6V8Rh2HMZJmSXpN0n8r6zPuOCQ0ekiaBdwLLAOGaP4L96HpndWUegxY2lO2Hnje9iDwfFk/0x0H7rR9CbCE5i2TQ8y8Y/E+cI3tLwCLgKXlnTkz7TiMuZ3mFRFjZtxxSGh81GJg2PZB28eATcDyaZ7TlLH9EvBOT/Fy4PGy/Dhw/ZROahrYPmz7p2X5KM0firnMsGPhxv8pq+eUj5lhxwFA0jyaN4w+1CqeccchofFRc4E3W+sjpWwm++zYmxjL90XTPJ8pJWkBcDnwCjPwWJRLMjuBI8BztmfkcQD+M/AfgN+1ymbccUhofJT6lOW55BlK0vnA08Adtt+b7vlMB9u/tb0ImAcslvTPp3tOU03SdcAR2zumey7TLaHxUSPA/Nb6PJrX0c5kb0uaA1C+j0zzfKaEpHNoAuMJ28+U4hl5LABs/2/gRZp7XjPtOFwFfF3SL2kuWV8j6a+YecchodHHq8CgpIWSzgVWAFumeU7TbQuwuiyvBp6dxrlMCUkCHgb22b6nVTWjjoWkAUmzy/IngX8NvM4MOw6277I9z/YCmr8J/8P2v2OGHQfIL8L7knQtzfXLWcAjtv/TNE9pykh6CvgSzX/5/Dbwp8B/BTYDnwN+Bdxou/dm+RlF0r8C/iewmw+uYX+H5r7GjDkWkv4FzQ3eWTT/yNxs+88l/RNm0HFok/Ql4N/bvm4mHoeERkREVMvlqYiIqJbQiIiIagmNiIioltCIiIhqCY2IiKiW0IiIiGoJjYiIqPZ/AVLgcJXFOVNWAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# plot learning rates\n",
     "plt.plot([x for x in clf.history['train']['lr']])"
@@ -251,15 +613,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEST VALID SCORE FOR census-income : -0.92661989\n",
+      "FINAL AUC TEST SCORE FOR census-income : 0.92234\n"
+     ]
+    }
+   ],
    "source": [
     "preds = clf.predict_proba(X_test)\n",
     "test_auc = roc_auc_score(y_score=preds[:,1], y_true=y_test)\n",
     "\n",
-    "print(f\"BEST VALID SCORE FOR {dataset_name} : {clf.best_cost}\")\n",
-    "print(f\"FINAL TEST SCORE FOR {dataset_name} : {test_auc}\")"
+    "print(f\"BEST VALID SCORE FOR {dataset_name} : {clf.best_cost:.8}\")\n",
+    "print(f\"FINAL AUC TEST SCORE FOR {dataset_name} : {test_auc:.5}\")"
    ]
   },
   {
@@ -271,9 +642,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully saved model at ./tabnet_model_test_1.zip\n"
+     ]
+    }
+   ],
    "source": [
     "# save tabnet model\n",
     "saving_path_name = \"./tabnet_model_test_1\"\n",
@@ -282,9 +661,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Device used : cuda\n",
+      "Device used : cuda\n"
+     ]
+    }
+   ],
    "source": [
     "# define new model with basic parameters and load state dict weights\n",
     "loaded_clf = TabNetClassifier()\n",
@@ -293,9 +681,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FINAL TEST SCORE FOR census-income : 0.922338917417995\n"
+     ]
+    }
+   ],
    "source": [
     "loaded_preds = loaded_clf.predict_proba(X_test)\n",
     "loaded_test_auc = roc_auc_score(y_score=loaded_preds[:,1], y_true=y_test)\n",
@@ -305,7 +701,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,11 +717,60 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.06492022, 0.01551775, 0.01916637, 0.02928418, 0.01400832,\n",
+       "       0.13389507, 0.10640079, 0.03205807, 0.07595738, 0.08574746,\n",
+       "       0.21974053, 0.16876696, 0.02087355, 0.01366334])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "clf.feature_importances_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "capital_gain      0.219741\n",
+       "capital_loss      0.168767\n",
+       "marital_status    0.133895\n",
+       "occupation        0.106401\n",
+       "sex               0.085747\n",
+       "race              0.075957\n",
+       "age               0.064920\n",
+       "relationship      0.032058\n",
+       "education         0.029284\n",
+       "hours_per_week    0.020874\n",
+       "fnlwgt            0.019166\n",
+       "workclass         0.015518\n",
+       "education_num     0.014008\n",
+       "native_country    0.013663\n",
+       "dtype: float64"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "important_features = pd.Series(data=clf.feature_importances_,index=train.columns[:-2])\n",
+    "important_features.sort_values(ascending=False,inplace=True)\n",
+    "\n",
+    "display(important_features.sort_values(ascending=False))"
    ]
   },
   {
@@ -337,7 +782,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,15 +791,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABGYAAARuCAYAAACRGjGeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzde5QfZH3n8e8z80smJJBwCeEeAQEL2mIVuUm3ttRi7cVWt2d7c7V1vZzWbWvdnvV42t12T8+23brqbq31Ulr1rN1Wj1q1LVrF29IECKDUghpA7pBwS7jkMsnvN8/+keEYgQyEPM9855e8Xud4yOTymSfjzO+ZefMjKbXWAAAAAGD+TWQfAAAAAOBAJcwAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhhv1WKeVFpZQ7ss8BwMLkngBgLu4J5oswA7NKKb9QSrm1lLKllPJ3pZTDs88EwMJQSjmmlPKpUspdpZRaSjkx+0wALByllB8vpVxWStlcStlQSnl/KeWQ7HMxHoQZiIhSyrMj4r0R8cqIOCoitkbEu1MPBcBCMhMRn4mIV2QfBIAFaUVE/EFEHBsRp0fE8RHxJ6knYmwIM6QopdxSSvntUsq/zD5D5eJSylGllEtKKQ+XUj5fSjlst5//0dny/GAp5SuzIeXRH3tpKeX62V93ZynlP+3hdf767M87/gl++Bcj4tO11q/UWh+JiN+NiJer3AA5Fto9UWvdWGt9d0Ss6/IbBmCvLMB74q9rrZ+ptW6ttW6KiPdHxAt7/N7Z/wgzZHpFRLw4Ik6LiJ+MiEsi4q0RsTJ2vW/++m4/95KIODUiVkXENRHx4d1+7OKIeH2t9ZCIeE5EfOGxr6iU8rsR8eqI+MFa6xP9d6LPjohrH32h1npTROyYPRsAORbSPQHAwrOQ74l/ExHX7d1vhwPVIPsAHND+tNa6MSKilPL/IuKeWutXZ1/+RERc+OhPrLX+5aPfLqX8XkRsKqWsqLU+GBE7I+KMUsq1s3V6026vo5RS3h4RZ0fED83+/CdycEQ89scejAjPmAHIs5DuCQAWngV5T5RSXhwRr4qIc/b1N8iBwTNmyLRxt29ve4KXD46IKKVMllL+qJRyUynloYi4ZfbnrJz95ysi4qURcWsp5cullPN22zk0Il4XEX/4JA+ij0TE8sd83/KIeHgvfj8AtLWQ7gkAFp4Fd0+UUs6NiL+OiH9ba13/NH5PHICEGcbBL0TEyyLiR2LXH6p14uz3l4iIWuu6WuvLYtfTEv8uIj6y26/dFBE/ERF/VUqZ67/xvC4iznz0hVLKyRExFREeTAEWvvm4JwAYX/NyT5RSvj8iPhURv1JrvbTlb4D9mzDDODgkIqYj4v6IWBoR//3RHyilLC6l/OLs0xB3RsRDETHa/RfXWr8Uu/5w30+UUvb0dMIPR8RPllJ+oJSyLCL+W0R8vNbqGTMAC9983BNRSlkSu6J9RMTU7MsALHzd74lSynNi19/e9x9rrZ/u8rtgvyXMMA4+FBG3RsSdEXF9RFz+mB9/ZUTcMvu0xDdExC89dqDW+rmI+OWI+FQp5flP8OPXzf7aD0fEPbHrwftXG/4eAOin+z0xa1vs+k9fIyK+OfsyAAvffNwTb46IIyPi4lLKI7P/84f/8pSUWmv2GQAAAAAOSJ4xAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJBvP5yhaXqbokls3nq3zayqJOb5qZPn8LVh2NuuyWyckuu8NDlzTfnLx/S/PNnoar+nwsDLbMdNmNLQf23wq7PbbEjjpdss+xvxsctKwuPuTw9rv3jtfjAxFROny4+ZsoIyJi8ff0+fdy03e1v9vLQ1ubb/binpgfvb6eKIP2n/vX4bD5Jrs5+KD2m48c2J/vPmrm0KVddocHtX+InLp/Z/PNiIi6Y0fzzbnuiXkNM0tiWZxTLpzPV/m0DVYe1WW3Trf/PzgiYrRpU5fdyeUruuze+7Izmm8e/ldrm2/2dM+/O7/L7qqrHumyG5f/S5/dMXFFvTT7CAeExYccHs96xZua765873g9PhBRpqaab9bp6eab4+j4Dx7cZfem3z+9+ebUJeuab/binpgfvb6emDz8yOabo3vvbb7Jd9TnPrf5Zln79eabEREx0+dfovey7UVnd9m97znt88NJH76j+WZExPCW25pvznVP+E+ZAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACDJPoWZUspLSinfKqXcWEp5S6tDAbB/cE8AMBf3BMA+hJlSymRE/FlE/FhEnBERP19Kaf93IAMwltwTAMzFPQGwy748Y+bsiLix1vrtWuuOiPibiHhZm2MBsB9wTwAwF/cEQOxbmDkuIm7f7eU7Zr/vu5RSXldKuaqUctXOmN6HVwfAmNnre2K4bcu8HQ6AdL6eAIh9CzPlCb6vPu47an1frfWsWutZi2JqH14dAGNmr++JwUHL5uFYACwQvp4AiH0LM3dExAm7vXx8RNy1b8cBYD/ingBgLu4JgNi3MLMuIk4tpZxUSlkcET8XEZ9qcywA9gPuCQDm4p4AiIjB0/2FtdZhKeWNEfHZiJiMiL+stV7X7GQAjDX3BABzcU8A7PK0w0xERK31HyPiHxudBYD9jHsCgLm4JwD27T9lAgAAAGAfCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgyT79rUwLxeSRRzbfHG7Y2HxzHJVDV3TZPfyv1nbZ7eGGd53TZffUN67pstvL/f/hvOabR/zF+LwfMD/qRMTOZSX7GCwAdXo6+wj7rd86+nN9di95pMtuDxNLlzbfLNv8+85xNrr33uwjsJceOP2g5ptH/POo+eY4WvzQsMvu1Ob2+aEuXdJ8M4MbBAAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBlkH6CF0b33Zh8h3c4fPavP8D9d1Wd3jJz6xiuyj7BXbnznuV12j1pbu+x2UUr7zTH67Y+zRRu3xDFvX5N9DBaAW/7gvOabJ/7O2uabPb1m/c1ddn/rxPZv24iIMmj/aWUdDptvRkTMbN3afLPWmeabwJ4d8RftH9M/e9fXmm9GRFx07HO77PYy+cVruuyu+mL7zVH7yRSeMQMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJBtkHONDc+Z/P77J73B+v6bJ7x1v7nPcZ7/1m883R/Q803+xp8tnP6rJ7ym9e3mV3rNSafQKeph3HLIvbXt/+cWf17/d5jOxh8tAVXXZHmx/sshsTk11mT/ydtV12x8nFp53UZfdnrr+3y+4nzjiyy24XpbTfdPXAvLrv9ec137zo2OaTY6med2aX3Vt+amnzzWf+/lebb0ZEzGzf3mV3TzxjBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIMsg9woNlxWM0+wl454XMP9xleeXj7zfsfaL/Z0dbVy7vsHnTz0i67M1u3dtmF3U3sjFh2x3g9TrY2PP3ELrtl7bVddu/51XO67K5615ouu0S87R9+qsvuM2Ntl90u6oH9OAP7g6X3zmQfYb81vXKqy27p8H9ZWdLnrLF9e5/dPfCMGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgyyD7AQjU47tguuye9ZW2X3V7quq932S2d3r7j5JVv/3SX3Y+cfnSXXZgPix7eGau+srH57qj5Yj9l7bXZR9grq961psvu4MTVzTeHt9zWfHMc/cyFl3fZ/fyvnd98c9Wf9Xn/gscqg/ZfFtXhsPkm33HQhu3ZR9hvjaZKl92ld7bfnX7eKc03IyIGX7i6y+6eeMYMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBlkH2ChGt51d5fdiUMO6bI78/DDXXZv+73zu+zuWDHTfPOUN93VfLOnj37v8Z2Wh512YT6UiFKyD5FrYrLP7syoy+zg+OO67M5suKf55uDkE5tvRkTc9OpjuuyuvmRrl93P/M2yLrvH/tmaLrswH+qow2Nkr/us1j67Y2aweVv70UNXtN+MiNHmB7vs9rL9sD7P35g+rP3mkuvvaD8a8/8VlWfMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJIP5fGVlyVRMnvKs5rt10WTzzZmvXd98MyJi5uGHu+yOXvS8Lrurf29Nl10i6nCYfYR0gxNXd9m96ZePb7654z2XN9/kidQow1H2IXLNjNfvf3jHnV12p3/sBc03py5Z13wzIuIZ/+WWLrvTL23/NoiI2HLGdJfdnT96VvPNRf90VfNNeEK1Np+cWLKk+WZExMz27V12x82Wkw9tvrmslOabERGx+cE+u50ccnufr1NmJtvnhzq9o/lmBs+YAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCSD+Xxldft0jK771ny+ygPG5JeuyT4C+7nP3vW15psXHdt8MiIinvFfb2u+uaFuab7J4+04dFHc9vL27xjHvu2W5pv0NXXJuuwjpJv6xz5vgy+957Iuu6999QVddmFczWzfnn2E/drdF0w23zzp732tGhExXNrn+RtHrd3cfLMed1TzzYiI2LSpz+4eeMYMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBlkH2ChmjztmV12R+tv6rLby/p3n91l98grJ5tvHvahK5tvRkSURX0+TOr0dJfdXl7yjB7vCzs6bDLOFm3cEse+bU32MdgLg+OO7bI7vPOu5pv3vPH85psREfHiB7rMLvvQii67r13dZRZgXp3ytvXNN0fNF8fTHS/t85ZY/vXDmm8e8+6rmm9m8IwZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASDKYz1dWJiZi4qClzXenzz+9+WZ8/ur2mx3d/5rzuuye9qtru+yOkzo9yj7CXhkcf1yX3eEddzbf3Pkjz2++GRGxeNP29qPX/3P7TR6nLJmKyWee1nx3dP365pvsMrzzri670z/2guabq961pvlmRES8q8/s1pef02V3/fvav20jIk758LD55sSXv9p8E+bL5FGruuyONt7TZXfczJxwdPPN+3+6/ecgERFHXHx5l92otcvsM//PTJfdHSva3xMxUdpvJvCMGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJI8aZgppfxlKeWeUsq/7vZ9h5dSPldKuWH2n4f1PSYAC5V7AoC5uCcA5vZUnjHzgYh4yWO+7y0RcWmt9dSIuHT2ZQAOTB8I9wQAe/aBcE8A7NGThpla61ci4oHHfPfLIuKDs9/+YET8dONzATAm3BMAzMU9ATC3p/tnzBxVa707ImL2n6v29BNLKa8rpVxVSrlqR93+NF8dAGPm6d0To63zdkAAUj2te2JnTM/bAQHmS/c//LfW+r5a61m11rMWlyW9Xx0AY+a77onJpdnHAWCB2f2eWBRT2ccBaO7phpmNpZRjIiJm/3lPuyMBsB9wTwAwF/cEwKynG2Y+FRGvmv32qyLik22OA8B+wj0BwFzcEwCznspfl/1/I2JtRDyrlHJHKeU1EfFHEfHiUsoNEfHi2ZcBOAC5JwCYi3sCYG6DJ/sJtdaf38MPXdj4LACMIfcEAHNxTwDMrfsf/gsAAADAExNmAAAAAJIIMwAAAABJhBkAAACAJE/6h/+2VGdmYmbr1ua7iz5/dfPNXsrzn91l94iL13bZXf/eF3TZPe3167rs9jC58og+w4cf2mV2uP6mLrsTZ57efLPXx27tMrq9xyqPUbdPx+j69dnHYC/U887ssjt1Sft7Yv17zm6+GRGdHnQizvgfG7rsnvbxW7vswjibeM73NN8c/es3m2+ymw5PMTjiL/p8TTVubr9wqsvukdfONN+s09PNNzN4xgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkGWQfYKGaWLasy+7M1dd12e3l8GMf7DM8Mdl+c2bUfjMiyqJFXXaH62/qstvLtuMPbr45dW3zScbccNWy2Phz5zffPepP1zTf7KbH42NEt8fIiXV97rVaSvPN095wZfPNnkZTU112/+SWy7vs/vaJ53bZhfkw86/fzD4Ce+m+5y5vvnnE1c0nx9Lqz27rsrvhvKXNN5efclLzzYiI0Y03d9ndE8+YAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCSD7AMsVGWRN01ExPDSlV12B8duab45vPOu5psREXXZQV12e5k8dEWX3YdOaP8xcWTzRcZdjYg6mX2KXL3unzo96rJbFi/uslu3beuyO05KKV12bx8e2mUXYD7N9Ll+iIiZqT6fjE1ub79Zdg7bjybwjBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIMsg+wEI12vxgl93J057ZZXe0/qYuu0e/c02X3WGX1T5GN97cZffXb/xml93/fcr3dNk98j1ru+zC7iZ3Riy7eyb7GKnK5GSX3dplNWJm69ZOy8xs395l95CJPrtdlNJldvL0U5tvlpsua74J7NnA9dPNood2dNndcvzi5pt16xjdaXPwjBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBkkH2AJiYm22/OjNpvRsRo/U1ddunn7++8usvuTxz3/C67MM7KsMZB9+1svztof93V4bD5ZkTEzNatXXbhUe/b8KJOy5vbT9bafjMi7rxoZfPNHR/ePz6thnEx2N7n8YGI4cGLuuyWHl9iT5QOo/PPM2YAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgySD7AE3MjLJP8JTd/Ifnddk95Z03ddmd2fxgl906Pd1lt4efOO75XXYnlizpsnv7bzyvy+5xf7ym/Wgp7TcjogwWtR/d2eesfLeJ4Uwsvm9r892Z4bD5ZkxMtt+MiB0/2udjePFn1nXZjUuP77N74R3NJyeXL2++GRExeuihLruTh67osnvPm5/RZbfE5vajnT7Ojn5H+zvt1rql+SawZ1uPav8cg0OaL46nie19vr6enG7/+XR9+JHmmxk8YwYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSDLIPcKCZWVz77G5+sMvuxNKlXXZnRqPmm3U4bL7ZU1ky1WV38UN93se6qH3OWha1f2grw9J8k8erJaIumsw+xlNTZ7JPsCAcsWRLl937O2zOTE93WO1nZsu2PsPj9HDm4wzYg+LhoZs62emiGKMvU+abZ8wAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAksF8vrIyGMTkylXNdze/6OTmm4f87eXNNyMinvnmPrvbf/wFXXan/mFdl10iRpsf7LJ75J+v7bLbw46LzuqyW2r7zZm1l7Yf5fEmSoyWLWo/23wxImqHd7SIWPyZ8Xrcvf+Fm7rsTp5xWvPN0fXrm2/2VJ59SpfdE95+U5fdu3/F/2fwXUrps9vp/hk3B90303xzYunS5psRETNbt3bZ7WW0tE8mmBi23yzLlrUfjYiY5//PPGMGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkGcznK6vDYYw23tN895C/bb8Z535f+82IiMv/pcvs1D+s67K7/t1nd9k9/a3far452vxg882IiLJocZfdunNHl91etr2s/fvCQZ+8svlmL6VuzT7CgeGRbTHx5a9mnyJXKX12a+0yO/qh53XZjS9e03zy7jef33wzImLL92/rsnvKu0Zddu8495EuuxHrO+3CmOr0uMsuh157f/PN0Vaf70VEbHjd9i67qy5u/zlO3bKl+WYGz5gBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJIPsAyxUg1vv6bI77LLaz8S0djdx8uouu6Nv3dhlt5eZRSX7CBwAdh61LO7+pfOb7x7z9jXNN7upNfsEe2Xyi9dkH+EpO+Z/jtH7QUcfuO2yLruvXn1Bl12AJ7LhB1c23zzyGzc03xxHx72zTybYcO6i5purrz+i+WZExMytW7vs7omvugEAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEjypGGmlHJCKeWLpZRvlFKuK6X8xuz3H15K+Vwp5YbZfx7W/7gALDTuCQDm4p4AmNtTecbMMCLeXGs9PSLOjYhfK6WcERFviYhLa62nRsSlsy8DcOBxTwAwF/cEwByeNMzUWu+utV4z++2HI+IbEXFcRLwsIj44+9M+GBE/3euQACxc7gkA5uKeAJjbXv0ZM6WUEyPi+yPiiog4qtZ6d8SuB9uIWLWHX/O6UspVpZSrdsb0vp0WgAVtX++J0dYt83VUABL4egLg8Z5ymCmlHBwRH4uI36y1PvRUf4ysQPgAACAASURBVF2t9X211rNqrWctiqmnc0YAxkCLe2Jy6bJ+BwQgla8nAJ7YUwozpZRFsetB9MO11o/PfvfGUsoxsz9+TETc0+eIACx07gkA5uKeANizp/K3MpWIuDgivlFrfftuP/SpiHjV7LdfFRGfbH88ABY69wQAc3FPAMxt8BR+zgsj4pUR8fVSytdmv++tEfFHEfGRUsprIuK2iPjZPkcEYIFzTwAwF/cEwByeNMzUWi+LiLKHH76w7XEAGDfuCQDm4p4AmNte/a1MAAAAALQjzAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkT+Wvyz4gDTfem32EhaH2mR1tfrDPcAejb92YfYS9c+73dZmd3N7pnaGDwYmrm2+WOxc33+TxZpbUePj0nc13j2m+COPr7ff9QKfl8bkngPFXB3v6i77YZ6XP27b0uCamd3QYnX+eMQMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJBtkHWLBmRn12z/7ePrtXfr3L7BHXli67g6OPar45s/nB5psREdMXPLvL7tQV67vsTtyyscvusodWNN/s9FEWw1tua75Z647mmzze1H01Tnv/9uxjpCrP7/OYU6++rsvuhjed32X36Hesab45OPnE5psREXWy07/nKn3u4C/++aouu0fE2i67MB/qeWc23xxcd3PzzYiI0UMPddkdN8d++vbmm1svOqv5ZkTE1KVf67Jbh8MuuztWLOqyu/Lr7T+fHt2/qflmBs+YAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASQbZB1iotrzinC67yz52RZfdXiZ31i67dfnBzTdnNmxsvhkRsejSa7rsztQ+b9uZRx7psrvpopObbx52ffPJiIgoU1PtR6dL+00eZ+fBE3H3BYc03z3myuaT3dSrr8s+wl45+h1rso/wlA2/fUv2ERaET3/+g112X/3+C7rswnwoa69tvjlqvsjuNrzk+OabK9+7tvlmRESfz/r7WfTIsMvuPc9b0nzzhG8d1XwzImJ46+1ddvfEM2YAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgySD7AAvV8stu7jN86Ious6PND3bZ3XpUn3Y3fOGq5puHr7+p+WZERNTaZ7eULrOTK5Z32T3yC7c33xw2X9xlYnn7t0F5YLL5Jo9XJyOmD+/0MQdERMQ1O1ZmHwFgny3bMMo+wn5r58F9MsG2o9t/jjfzwObmmxk8YwYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSDObzlZWpxTG5+qT2w5sfaj452nhP882eHvnZc7rsHv2ONV12iYha++weeUSX2eEN326+OXn6qc03IyI2vGhl882dH51qvsnjLd48ipM+0f4xvdNHGx2NXvS85puTX7qm+WZPOy46q8vum9ad2WX3xPPbb5Y117YfhXlSBn2+1KrDYZfdcTO9fLL55sGHHdZ8MyJitGlTl91eFj3S531syb3tPybK4kXNNzN4xgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkGcznK6vTO2J0483z+SoPGAd/9Iouu2XR4i67Z63b1nxz3fP6nDVmRl1m6/lndtkdrbm2y24Po2/c0GX3yA67365bmm/yeDsPmYw7f3hF891jr24+SWeTX7om+wjpFn/2qi67n33fZV123/DzF3TZhflQBu2/LKrDYfNNvmPll25vvjnctKn5Jt/xyLN2NN+cOenY5psREXH/A31298AzZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQJLBfL6ysmgQg5VHNd99+JxnNN886JNXNt/s6d43nNdl98j3rO2yu+65kx1WRx02+ylrru2zO+jzYV2Hw+abO17yguabEREH3byp+Wa55bLmmzze4s07Y/XH7mq+2/69l962/+TZzTeXfHq87vZHfvacLrs/fEn7t21ExCk/uLP55sSXv9p8E55Ij89zBscc3XwzImJ494Yuu+OmHrK0+ebdv3V+882IiGPeeUWX3Zjp8/VPGdUuuyd9pMPo177ZYXT+ecYMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBnM5yurO4cx3LCx+e5Bn2y/2cudH392l93jXr62yy7j5+5fO7vL7tH/a03zzcWfWdd8MyJi1GGz1ukOqzxWnd4Rw2/fkn2Mp2Ty1JO77NY7N3TZndm6tcvu+2+7rMvua1e33xz+8PPbj0bE4AtXd9ld8YUbuuwe/NEHuuwC3214d5/Hc3a557wjmm8e/8FvNt+MiBjN9PjstKNOT9+498zFzTdPuHJZ882IiNHmB7vs7olnzAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAECSQfYBDjSrX317l91Rl1V6+sBtl3XZffXqLrMwL2YOWxZbLjyn+e6yj13RfHN0w7ebb0ZETC5f3mW3l9euviD7CE/Z4AtXZx9hr4zuf6DL7r//Vp/PRT70rBPaj05Mtt+M/9/evQfZXZ73AX/e3ZW0SAaEhAAhKYibMcSxDQYMtift2GaM4wtOm0ySOjaZZuK2aVI7qevaTdOZTqeOE9rE6bT1pU5tmLiuPdiJb+MLwaapgzBgDJi7sLhfdMNCQqDL7r79Q+sag3a1Mu+7zzni85lhds+Z1XefOfzO7znnq592I+LsM9pn3nJ1+0xgRmO7a/PMXufdYTOyu8+7y13L2/8/i0WL2mcmcMUMAAAAQBLFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAkrHsAQbV6PJlXXIntz7WJbeXuz5ybpfcEy+fbJ658P/e0jwzImJ02VFdcn/jZ17dJbeXsZPWNs+c2HBv88yIiCilfWZtH8mzjfxwZyz53Heyx0g1uX179ggHZeQlL+qSO3XzHc0z7/0P5zfPjIjYc+xEl9yTPjPVJfey07rE9jHV/vVCRERc+/32mfWp9pnAjJbeubN5Zu3xGjIiog7XC8l737ykS+4R97TPrE8eGudeV8wAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkOWAxU0oZL6VcW0q5qZRyaynl30/fv6yUckUpZf30xz6/UxiAgWZPADAbewJgdnO5YmZ3RLym1vrSiHhZRFxYSjkvIt4XEVfWWk+NiCunbwPw/GNPADAbewJgFgcsZuo+T0zfXDD9X42IiyLi0un7L42It3aZEICBZk8AMBt7AmB2c/oZM6WU0VLKjRGxKSKuqLV+JyKOrbU+EhEx/fGYfmMCMMjsCQBmY08AzGxOxUytdbLW+rKIWB0R55ZSXjzXb1BKeWcp5fpSyvV7Y/dPOycAA8yeAGA29gTAzA7qtzLVWrdFxFURcWFEbCylrIyImP64aYY/87Fa69m11rMXxKLnOC4Ag8yeAGA29gTAs83ltzKtKKUsnf78sIh4XUTcERFfjIiLp7/s4oj4Qq8hARhc9gQAs7EnAGY3NoevWRkRl5ZSRmNfkfPZWuuXSynrIuKzpZTfjIj7I+KXO84JwOCyJwCYjT0BMIsDFjO11psj4sz93L81Il7bYygAhoc9AcBs7AmA2R3Uz5gBAAAAoB3FDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAkgP+uuxhMLpiRfPMyS1bmmf2NLp8WZfc0/9zn8dhcv2G5pm1eeI+E49u7JTcx+gRR3TJffKj7R/hhRc0j4yIiJEXvKB5ZnlCjz0f9h67JB6++JXNc4+/5OrmmewzdfMd2SPM2do/XJc9wkD4yH3f7pL7T094dZdcgP154HWHN89cfV2vdxTDZeW3J/oElw6ZJ67qEBoR8/z6xjsNAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkY9kDtDC5eXP2COkmtz7WJ7hX7hDZ9vbzuuQuvWxdl9zJ7du75I6UpV1ye5jasaN5Zq1TzTPZv5GJ7Ang0LZkpGSPAPCcrf6jq5tnfv3hG5tnRkS8/viXdcntZdFXr8seYc4OlVforpgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIMpY9wKAaW7O6S+7EAw92ye3l7g+d1yX3tD/a0DxzcuOm5pkREUsvW9cld9j88HOrmmeuiPubZzLcFmzcGcf92dXZY6QaWbKkS+7Uzp1dcve8/uwuuQu/fn3zzO2/1menbXz93i65J3y6dMl9x4m9Xv5NdMqF/saOO7Z55sSjG5tn8mPlnJ9rnvmGk8abZ+6zq1NuHz+45PwuuWuubL8nDrv6zuaZERGT27d3yZ2JK2YAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSjGUP0MKWf3J+88yjP7queeYwOuXd13TJLSuPa545eupJzTMjItb/1rFdck9673AdYys+PFzzMpwmViyJzb/U/py+4iPDc/xO7dyZPcJBWfj167NHmLMjPt1npx3x6S6x3Xzpoe92yX3T6rPbh9baPhP2Y+LRjdkjcJCeOu6w5pnj1+1qnjmMTvlf27vkrn/74c0zT7vnmOaZERGxvc9jMBNXzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACQZyx6ghaM/ui57hDkbXb6sS+7k1se65PYy8cij2SPM2Unv3dAl97/f9+0uub99wqu75MJ8GJmIWLx5KnuMVCOHH94ld2rHji65DJ+vPHlkn+Ba22eOjLbPjIhy1untQ2/9u/aZwIx2H9n+GoPx5onDqS7qc+4d2VPah27b3j4zgStmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSjGUPMKjGTjyhS+7EPfd1ye1l15vO7ZI7/pXr2ofW2j4zIspYn6fJb5/w6i65vTzy16c3z1z51tubZ0ZERCntM/scXjzD5IKIHWtGm+cuaZ7Yz9SOHdkjcIh79fjGLrkfjlPah05Nts+MiHr9LR1Cd7XPBGa0Y037awyObJ44nPYsXdQld+U1Hc7py5e2z4yI2LipT+4MXDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQZCx7gEE1cc99XXJHlizpkju1c2eX3M0v7XOIHLX4Fc0zj7xpS/PMiIh62MI+uTfe1iW3l+N/aX3zzNo88UfB3ZLpbOEP98Tqy9uffyeaJ/Yztur4LrkTDz3cJXfrb53fJXf5X1zbPLOcdXrzzIiITWcf3iX36Juf7JL7j37lpV1yS9zUJRfmw6O/98rmmas+cWvzzIiIyW2Pd8kdNmsuab8nnrzo3OaZERGLv3JDl9w60ecVzuiuyS65h21of+xO3vWD5pkZXDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQZCx7gOebx/7hS7rkHvWZG7rkrr18U5fcsneieebEhnubZ/Y08ZqXd8lduPXJLrlTN93ePHNkfLx5ZkTEyMpjm2eWBxc2z+TZ9ixfGPe97YTmuav++KHmmb1MLT+iT/BDD3eJPeZvN3fJnZyabJ5Zr7+leWZExIrru8R2s/NrJ3XJXXJhh9CR0Q6hEdHh+GK4HfdnVzfPdJT1teuCM5tnHvaFa5tnRkTULqkdlT6xd71zRfPM0/58d/PMiIiJBx7skjsTV8wAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkGcseYFCNrTyuS+7Sy9Z1ya1dUiNuf89RXXJP+52bu+T2UM75uS65Y9/8bpfcqS6pEZN//6z2oVfd0D4zIqbuua95Zq17mmfybAse3Rmr/vjq7DFSTd18R/YIB2XP8Ud0yR29s33m+v/yivahETH6ZJ+/5zr58h1dcpdceEuX3C6mJrMnAAbU4vu3N890xtlnw2/0yV39V+3fqdQdfXblfHPFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAEsUMAAAAQBLFDAAAAEASxQwAAABAkrHsAQbVxCOPdsm95wPnd8k9+T/e3CX3Rb9/R5fcGGt/6NXdu5tnRkTU677fJXf0tFO65O742eVdchd//jvtQ0tpnxkRo8uXNc8sPxxtnsl+HL44Js8+q3ns6FU3NM/sZfcbzumSu+ir13XJ/eHvP9El9+hvtc889d3Xtw+NiJia7BJbR/qcd3a9+dwuueNfurZ9aKc9EbX2yQXmzcZXtX+9d/StzSOH0omX9jn3Pvzz7d8DLvnG3uaZGVwxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBEMQMAAACQRDEDAAAAkEQxAwAAAJBkzsVMKWW0lPK9UsqXp28vK6VcUUpZP/3xqH5jAjDo7AkAZmJHAMzsYK6YeVdE3P602++LiCtrradGxJXTtwF4/rInAJiJHQEwgzkVM6WU1RHxxoj4+NPuvigiLp3+/NKIeGvb0QAYFvYEADOxIwBmN9crZj4UEe+NiKmn3XdsrfWRiIjpj8fs7w+WUt5ZSrm+lHL93tj9nIYFYGA12RN79uzsPykA8+2n3hER3k8Ah74DFjOllDdFxKZa63d/mm9Qa/1YrfXsWuvZC2LRTxMBwABruScWLlzSeDoAMj3XHRHh/QRw6Bubw9e8KiLeUkr5hYgYj4gjSil/GREbSykra62PlFJWRsSmnoMCMLDsCQBmYkcAHMABr5iptb6/1rq61ro2In41Ir5Za/31iPhiRFw8/WUXR8QXuk0JwMCyJwCYiR0BcGAH81uZnumDEXFBKWV9RFwwfRsAfsSeAGAmdgTAtLn8U6b/r9Z6VURcNf351oh4bfuRABhW9gQAM7EjAPbvuVwxAwAAAMBzoJgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASHJQv5WJ5+7Ef7OuS+5Ul9SIHb9yXpfcwz9zTfPMsmBh88yIiHv+3cu75K79wz7HwuI77+6S++Q/eEXzzMWf/07zzIiIyS1bm2fWOtk8k2ebXFDiidXtn8tHNk/sZ/G6u7rk9jqCj31Pnw001eGcXvfuaZ4ZETEyPt4n97hjuuSueX+fY2zzlzqE1tohFJ6tjLV/W1QnJppn8mOLt/R6B8SepX1qgvEt7TPL2tXtQyMibuuzK2fiihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkY9kDtDB69PLmmXX1sc0zIyKmbrytS24vh23e2yV3dMWK5pmTmzc3z4yIOPlDd3bJneyS2s+ms9r3uGs/3zwyIiJGxsebZ5ZdpXkmzza1IOKpFe2PtSObJ/Yzue3x7BEOyuSdd2ePkG5q164+uffe3yX3T9f8XZfct8eruuTCfKgTE9kjcJCeWDnaPHNx88ThtPDxPs+HsaUdrgsph8ZrdFfMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJFHMAAAAACRRzAAAAAAkUcwAAAAAJBnLHqCFyce2tQ/dsrV9ZkSUsT4PeZ2Y6JI7vmFzl9y7331K88y1f9Bn1smtj3XJLYsWdcmtu3d3yV37b9e1Dy2lfWZEPPi7ZzXP3HPpVc0z2b/qrwygqz21Zo8AA2dszermmRMPPNg8kx87/qsPN8/s845q+Izt2NMl97EXL2ieufz7C5tnZvDyFwAAACCJYgYAAAAgiWIGAAAAIIliBgAAACCJYgYAAAAgiWIGAAAAIIliBgAAACCJYgYAAAAgiWIGAAAAIIliBgAAACCJYgYAAAAgiWIGAAAAIIliBgAAACCJYgYAAAAgiWIGAAAAIIliBgAAACCJYgYAAAAgiWIGAAAAIIliBgAAACCJYgYAAAAgyVj2AE1MTTaPHHnJi5pnRkRM3XxHl9xeJh98uEvuL7/xnuaZN1yyrHlmRMTktse75Na9E11yh0qtXWKPv+Tq5pkP1J3NM3m2MhUxuit7ilwj4+Ndcqd29XlgR5d3OvdufaxLLhEbJl6QPQIMnKlOr/foaLL9e0D2eer4w7rkTh3Z/v3PyP0bm2dGRMz30eWKGQAAAIAkihkAAACARNC0fAAADEhJREFUJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCSKGQAAAIAkihkAAACAJIoZAAAAgCRj2QMMqnr7huwRBkKdmOiS+5lvvLp55kmPX9M8s6cf/Mk5XXJPfs9wPQ7wdLVETC3IniLX1K5d2SMclMmtj2WPwEE6Y8HO7BFg4Ezt2JE9Agdp76plzTPLfQ80zxxG45v39Ame6PAi7/Al7TMjIjb2iZ2JK2YAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSjGUPMKjq3j1dcstYn4e8Tkx0yf3Bp87skvvCf3Zr88zJWptnRkSM/uxpXXJPfs81XXJ72XPhOc0zF37tuuaZDLcFm3bGcR+6OnsMDsLoGS/skjt5213NM9dfdlbzzIiIsnVhl9wXfmJbl9y3rekSCzCv6oL21xiU5onDacMvjnfJXfmtDqGbtnYInX+umAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEiimAEAAABIopgBAAAASKKYAQAAAEgyNp/frIyNxeiyFc1zJ045vnlmWXdT88yIiDox0SV32zvO75J78tvWdcmd7JLax+Std2aPcHBK6RK78GvXNc986q3nNs+MiBh7cqp5Zl3X57nATyqHjcfIi85onjt1423NM9ln8ra7uuRO/b0zm2ee+o4bmmf2tPt1L++Su+WvT++Su/IDHV5WXvv99pkwT8qiRV1y6+7dXXKHza5lC5tnHrH2Z5pnRkRM3Ht/l9xe1vxNn3drj522oHnm0pE+733mmytmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSjM3vdxuNWHZk89injhtvnrm4eWJfR39jQ5fciS6pEaNL2x8Hk9seb545lGrNnmDOXnD7Y11y7//FY5pnTtxUmmfybHuXjMbmc9qfH5bf2DySzkb+z/eyR0i34G++2yX35sv6PCFef92ZXXJhPowsWdI8c2rnzuaZ/NjC7e3fqUzce3/zzGE0/mifY3fn645oH7rquPaZERHz/N7SFTMAAAAASRQzAAAAAEkUMwAAAABJFDMAAAAASRQzAAAAAEkUMwAAAABJFDMAAAAASRQzAAAAAEkUMwAAAABJFDMAAAAASRQzAAAAAEkUMwAAAABJFDMAAAAASRQzAAAAAEkUMwAAAABJFDMAAAAASRQzAAAAAEkUMwAAAABJFDMAAAAASRQzAAAAAEkUMwAAAABJxubzm9Vdu2Pyzrub5y7ukLnlnec3z4yIOPpj67rkTjy6sUvuDy7p8zi88OOb24due7x9ZkTEyGif3KnJPrmdjC5f1jyzx/kgImLVB9vnPlh3Ns/k2ca27Izl/6PPeZI+dr353C6541+6tnnmw+95ZfPMiIgnTproknvqp/Z0yX398V1iI6L2Cobupnba88Nm/LaHmmf2OZsPn/X/alGX3GVXlOaZU3ff2zwzgytmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkihmAAAAAJIoZgAAAACSKGYAAAAAkpRa6/x9s1I2R8R9c/zyoyNiS8dxWhqmWSOGa95hmjViuOYdplkj8uc9oda6IvH7Py/YEwNjmOYdplkjhmveYZo1In9ee2Ie2BMDY5jmHaZZI4Zr3mGaNSJ/3hn3xLwWMwejlHJ9rfXs7DnmYphmjRiueYdp1ojhmneYZo0Yvnnpb5iOiWGaNWK45h2mWSOGa95hmjVi+Oalv2E6JoZp1ojhmneYZo0YrnmHadaIwZ7XP2UCAAAASKKYAQAAAEgyyMXMx7IHOAjDNGvEcM07TLNGDNe8wzRrxPDNS3/DdEwM06wRwzXvMM0aMVzzDtOsEcM3L/0N0zExTLNGDNe8wzRrxHDNO0yzRgzwvAP7M2YAAAAADnWDfMUMAAAAwCFt4IqZUsqFpZQ7Syl3l1Lelz3PbEopa0op3yql3F5KubWU8q7smQ6klDJaSvleKeXL2bMcSCllaSnl8lLKHdOP8fnZM82klPJ708fALaWUT5dSxrNnerpSyv8spWwqpdzytPuWlVKuKKWsn/54VOaMPzLDrJdMHwc3l1L+qpSyNHNGctkTfdkTfdgT7dgTHIg90Zc90Yc90c4w7omBKmZKKaMR8d8i4g0RcUZE/Fop5YzcqWY1ERH/stZ6ekScFxH/fMDnjYh4V0Tcnj3EHP15RHyt1vqiiHhpDOjcpZRVEfEvIuLsWuuLI2I0In41d6pn+WREXPiM+94XEVfWWk+NiCunbw+CT8azZ70iIl5ca31JRNwVEe+f76EYDPbEvLAnGrMnmvtk2BPMwJ6YF/ZEY/ZEc5+MIdsTA1XMRMS5EXF3rXVDrXVPRPzviLgoeaYZ1VofqbXeMP35jtj3RF+VO9XMSimrI+KNEfHx7FkOpJRyRET8fET8RURErXVPrXVb7lSzGouIw0opYxGxOCIeTp7nJ9Ra/zYiHnvG3RdFxKXTn18aEW+d16FmsL9Za63fqLVOTN+8JiJWz/tgDAp7oiN7oit7ohF7ggOwJzqyJ7qyJxoZxj0xaMXMqoh44Gm3H4wBPjE9XSllbUScGRHfyZ1kVh+KiPdGxFT2IHNwUkRsjohPTF8q+fFSypLsofan1vpQRPyniLg/Ih6JiMdrrd/InWpOjq21PhKx70VBRByTPM9c/eOI+Gr2EKSxJ/qyJzqwJ+adPfH8Zk/0ZU90YE/Mu4HbE4NWzJT93DfwvzaqlPKCiPhcRLy71ro9e579KaW8KSI21Vq/mz3LHI1FxFkR8eFa65kRsTMG59K4nzD9bykviogTI+L4iFhSSvn13KkOTaWUP4h9l/x+KnsW0tgTndgT/dgT88eeIOyJbuyJfuyJ+TOoe2LQipkHI2LN026vjgG7hOuZSikLYt9J9FO11s9nzzOLV0XEW0op98a+SzpfU0r5y9yRZvVgRDxYa/3R3xhcHvtOrIPodRFxT611c611b0R8PiJemTzTXGwspayMiJj+uCl5nlmVUi6OiDdFxNtqrQP/Aotu7Il+7Il+7Il5YE8wzZ7ox57ox56YB4O8JwatmLkuIk4tpZxYSlkY+37g0ReTZ5pRKaXEvn+zeHut9U+z55lNrfX9tdbVtda1se9x/WatdWBb2FrroxHxQCnltOm7XhsRtyWONJv7I+K8Usri6WPitTGgP1jsGb4YERdPf35xRHwhcZZZlVIujIh/HRFvqbU+mT0PqeyJTuyJruyJzuwJnsae6MSe6Mqe6GzQ98RAFTPTP4zndyLi67HvQPxsrfXW3Klm9aqIeHvsa4tvnP7vF7KHOoT8bkR8qpRyc0S8LCI+kDzPfk238JdHxA0R8f3Y97z6WOpQz1BK+XRErIuI00opD5ZSfjMiPhgRF5RS1kfEBdO3080w63+NiMMj4orp59lHUockjT3BM9gTjdgTHCrsCZ7BnmjEnuirDNgVPAAAAADPGwN1xQwAAADA84liBgAAACCJYgYAAAAgiWIGAAAAIIliBgAAACCJYgYAAAAgiWIGAAAAIIliBgAAACDJ/wNCNkTGC/diNAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 1440x1440 with 3 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, axs = plt.subplots(1, 3, figsize=(20,20))\n",
     "\n",
     "for i in range(3):\n",
     "    axs[i].imshow(masks[i][:50])\n",
-    "    axs[i].set_title(f\"mask {i}\")\n"
+    "    axs[i].set_title(f\"mask {i}\")"
    ]
   },
   {
@@ -366,11 +824,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0]\tvalidation_0-error:0.14902\n",
+      "Will train until validation_0-error hasn't improved in 20 rounds.\n",
+      "[10]\tvalidation_0-error:0.14002\n",
+      "[20]\tvalidation_0-error:0.13629\n",
+      "[30]\tvalidation_0-error:0.13008\n",
+      "[40]\tvalidation_0-error:0.12574\n",
+      "[50]\tvalidation_0-error:0.12791\n",
+      "[60]\tvalidation_0-error:0.12574\n",
+      "Stopping. Best iteration:\n",
+      "[44]\tvalidation_0-error:0.12449\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "XGBClassifier(base_score=0.5, booster='gbtree', colsample_bylevel=1,\n",
+       "              colsample_bynode=1, colsample_bytree=1, gamma=0, gpu_id=-1,\n",
+       "              importance_type='gain', interaction_constraints=None,\n",
+       "              learning_rate=0.1, max_delta_step=0, max_depth=8,\n",
+       "              min_child_weight=1, missing=nan, monotone_constraints=None,\n",
+       "              n_estimators=1000, n_jobs=-1, nthread=-1, num_parallel_tree=1,\n",
+       "              random_state=0, reg_alpha=0, reg_lambda=1, scale_pos_weight=1,\n",
+       "              seed=0, silent=None, subsample=0.7, tree_method=None,\n",
+       "              validate_parameters=False, verbosity=0)"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from xgboost import XGBClassifier\n",
     "\n",
@@ -399,8 +893,32 @@
     "\n",
     "clf_xgb.fit(X_train, y_train,\n",
     "        eval_set=[(X_valid, y_valid)],\n",
-    "        early_stopping_rounds=40,\n",
+    "        early_stopping_rounds=20,\n",
     "        verbose=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.924052\n",
+      "0.9196\n"
+     ]
+    }
+   ],
+   "source": [
+    "preds = np.array(clf_xgb.predict_proba(X_valid))\n",
+    "valid_auc = roc_auc_score(y_score=preds[:,1], y_true=y_valid)\n",
+    "print(round(valid_auc,6))\n",
+    "\n",
+    "preds = np.array(clf_xgb.predict_proba(X_test))\n",
+    "test_auc = roc_auc_score(y_score=preds[:,1], y_true=y_test)\n",
+    "print(round(test_auc,6))"
    ]
   },
   {
@@ -408,15 +926,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "preds = np.array(clf_xgb.predict_proba(X_valid))\n",
-    "valid_auc = roc_auc_score(y_score=preds[:,1], y_true=y_valid)\n",
-    "print(valid_auc)\n",
-    "\n",
-    "preds = np.array(clf_xgb.predict_proba(X_test))\n",
-    "test_auc = roc_auc_score(y_score=preds[:,1], y_true=y_test)\n",
-    "print(test_auc)"
-   ]
+   "source": []
   }
  ],
  "metadata": {
@@ -435,7 +945,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/regression_example.ipynb
+++ b/regression_example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10,7 +10,7 @@
     "\n",
     "import torch\n",
     "from sklearn.preprocessing import LabelEncoder\n",
-    "from sklearn.metrics import mean_squared_error\n",
+    "from sklearn.metrics import mean_squared_error, roc_auc_score\n",
     "\n",
     "import pandas as pd\n",
     "import numpy as np\n",
@@ -26,12 +26,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Download census-income dataset"
+    "# Download census-income dataset\n",
+    "\n",
+    "* Target is binary, if income is >= 50K or not.\n",
+    "* Data source: https://archive.ics.uci.edu/ml/datasets/Census+Income"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,9 +45,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "File already exists.\n"
+     ]
+    }
+   ],
    "source": [
     "out.parent.mkdir(parents=True, exist_ok=True)\n",
     "if out.exists():\n",
@@ -63,18 +74,216 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
-    "train = pd.read_csv(out)\n",
-    "target = ' <=50K'\n",
+    "# column headers/feature names\n",
+    "feature_names = [\"age\", \"workclass\", \"fnlwgt\", \n",
+    "                        \"education\", \"education_num\", \n",
+    "                        \"marital_status\", \"occupation\",\n",
+    "                        \"relationship\", \"race\", \"sex\", \n",
+    "                        \"capital_gain\", \"capital_loss\", \n",
+    "                        \"hours_per_week\", \"native_country\", \"income\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train = pd.read_csv(out,header=None,names=feature_names)\n",
+    "target = \"income\" #' <=50K'\n",
     "if \"Set\" not in train.columns:\n",
     "    train[\"Set\"] = np.random.choice([\"train\", \"valid\", \"test\"], p =[.8, .1, .1], size=(train.shape[0],))\n",
     "\n",
     "train_indices = train[train.Set==\"train\"].index\n",
     "valid_indices = train[train.Set==\"valid\"].index\n",
     "test_indices = train[train.Set==\"test\"].index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>age</th>\n",
+       "      <th>workclass</th>\n",
+       "      <th>fnlwgt</th>\n",
+       "      <th>education</th>\n",
+       "      <th>education_num</th>\n",
+       "      <th>marital_status</th>\n",
+       "      <th>occupation</th>\n",
+       "      <th>relationship</th>\n",
+       "      <th>race</th>\n",
+       "      <th>sex</th>\n",
+       "      <th>capital_gain</th>\n",
+       "      <th>capital_loss</th>\n",
+       "      <th>hours_per_week</th>\n",
+       "      <th>native_country</th>\n",
+       "      <th>income</th>\n",
+       "      <th>Set</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>32556</th>\n",
+       "      <td>27</td>\n",
+       "      <td>Private</td>\n",
+       "      <td>257302</td>\n",
+       "      <td>Assoc-acdm</td>\n",
+       "      <td>12</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>Tech-support</td>\n",
+       "      <td>Wife</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>38</td>\n",
+       "      <td>United-States</td>\n",
+       "      <td>&lt;=50K</td>\n",
+       "      <td>valid</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>32557</th>\n",
+       "      <td>40</td>\n",
+       "      <td>Private</td>\n",
+       "      <td>154374</td>\n",
+       "      <td>HS-grad</td>\n",
+       "      <td>9</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>Machine-op-inspct</td>\n",
+       "      <td>Husband</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>40</td>\n",
+       "      <td>United-States</td>\n",
+       "      <td>&gt;50K</td>\n",
+       "      <td>train</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>32558</th>\n",
+       "      <td>58</td>\n",
+       "      <td>Private</td>\n",
+       "      <td>151910</td>\n",
+       "      <td>HS-grad</td>\n",
+       "      <td>9</td>\n",
+       "      <td>Widowed</td>\n",
+       "      <td>Adm-clerical</td>\n",
+       "      <td>Unmarried</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>40</td>\n",
+       "      <td>United-States</td>\n",
+       "      <td>&lt;=50K</td>\n",
+       "      <td>train</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>32559</th>\n",
+       "      <td>22</td>\n",
+       "      <td>Private</td>\n",
+       "      <td>201490</td>\n",
+       "      <td>HS-grad</td>\n",
+       "      <td>9</td>\n",
+       "      <td>Never-married</td>\n",
+       "      <td>Adm-clerical</td>\n",
+       "      <td>Own-child</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>20</td>\n",
+       "      <td>United-States</td>\n",
+       "      <td>&lt;=50K</td>\n",
+       "      <td>train</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>32560</th>\n",
+       "      <td>52</td>\n",
+       "      <td>Self-emp-inc</td>\n",
+       "      <td>287927</td>\n",
+       "      <td>HS-grad</td>\n",
+       "      <td>9</td>\n",
+       "      <td>Married-civ-spouse</td>\n",
+       "      <td>Exec-managerial</td>\n",
+       "      <td>Wife</td>\n",
+       "      <td>White</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>15024</td>\n",
+       "      <td>0</td>\n",
+       "      <td>40</td>\n",
+       "      <td>United-States</td>\n",
+       "      <td>&gt;50K</td>\n",
+       "      <td>test</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       age      workclass  fnlwgt    education  education_num  \\\n",
+       "32556   27        Private  257302   Assoc-acdm             12   \n",
+       "32557   40        Private  154374      HS-grad              9   \n",
+       "32558   58        Private  151910      HS-grad              9   \n",
+       "32559   22        Private  201490      HS-grad              9   \n",
+       "32560   52   Self-emp-inc  287927      HS-grad              9   \n",
+       "\n",
+       "            marital_status          occupation relationship    race      sex  \\\n",
+       "32556   Married-civ-spouse        Tech-support         Wife   White   Female   \n",
+       "32557   Married-civ-spouse   Machine-op-inspct      Husband   White     Male   \n",
+       "32558              Widowed        Adm-clerical    Unmarried   White   Female   \n",
+       "32559        Never-married        Adm-clerical    Own-child   White     Male   \n",
+       "32560   Married-civ-spouse     Exec-managerial         Wife   White   Female   \n",
+       "\n",
+       "       capital_gain  capital_loss  hours_per_week  native_country  income  \\\n",
+       "32556             0             0              38   United-States   <=50K   \n",
+       "32557             0             0              40   United-States    >50K   \n",
+       "32558             0             0              40   United-States   <=50K   \n",
+       "32559             0             0              20   United-States   <=50K   \n",
+       "32560         15024             0              40   United-States    >50K   \n",
+       "\n",
+       "         Set  \n",
+       "32556  valid  \n",
+       "32557  train  \n",
+       "32558  train  \n",
+       "32559  train  \n",
+       "32560   test  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train.tail()"
    ]
   },
   {
@@ -88,9 +297,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "workclass 9\n",
+      "education 16\n",
+      "marital_status 7\n",
+      "occupation 15\n",
+      "relationship 6\n",
+      "race 5\n",
+      "sex 2\n",
+      "native_country 42\n",
+      "income 2\n",
+      "Set 3\n"
+     ]
+    }
+   ],
    "source": [
     "categorical_columns = []\n",
     "categorical_dims =  {}\n",
@@ -115,7 +341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,10 +351,12 @@
     "\n",
     "cat_idxs = [ i for i, f in enumerate(features) if f in categorical_columns]\n",
     "\n",
+    "# cat_dims = number of unique values in variable/column\n",
     "cat_dims = [ categorical_dims[f] for i, f in enumerate(features) if f in categorical_columns]\n",
     "\n",
-    "# define your embedding sizes : here just a random choice\n",
-    "cat_emb_dim = [5, 4, 3, 6, 2, 2, 1, 10]"
+    "# define your embedding sizes : A good heuristic is half the # of unique values, up to a maximum of 50. Here our variables have low cardinality. Note that `Set` isn't a feature\n",
+    "cat_emb_dim = [min(v//2+1,50) for v in categorical_dims.values()][:-2] # last 2 variables are target and Set indicator\n",
+    "# print(\"categoricals embeddings dimensions:\",cat_emb_dim) ## [5, 9, 4, 8, 4, 3, 2, 22]"
    ]
   },
   {
@@ -140,9 +368,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Device used : cuda\n"
+     ]
+    }
+   ],
    "source": [
     "clf = TabNetRegressor(cat_dims=cat_dims, cat_emb_dim=cat_emb_dim, cat_idxs=cat_idxs)"
    ]
@@ -156,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -172,7 +408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,11 +417,162 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Will train until validation stopping metric hasn't improved in 50 rounds.\n",
+      "---------------------------------------\n",
+      "| EPOCH |  train  |   valid  | total time (s)\n",
+      "| 1     | -0.31946 |  -0.17994 |   4.8       \n",
+      "| 2     | -0.15280 |  -0.32955 |   8.4       \n",
+      "| 3     | -0.13622 |  -0.26676 |   12.1      \n",
+      "| 4     | -0.13178 |  -0.22621 |   15.7      \n",
+      "| 5     | -0.12743 |  -0.20013 |   19.3      \n",
+      "| 6     | -0.12709 |  -0.15417 |   22.8      \n",
+      "| 7     | -0.12471 |  -0.12461 |   26.4      \n",
+      "| 8     | -0.12268 |  -0.12380 |   29.9      \n",
+      "| 9     | -0.12287 |  -0.12278 |   33.5      \n",
+      "| 10    | -0.12107 |  -0.12182 |   37.2      \n",
+      "| 11    | -0.11992 |  -0.11989 |   41.2      \n",
+      "| 12    | -0.11934 |  -0.11802 |   45.0      \n",
+      "| 13    | -0.11818 |  -0.11708 |   48.7      \n",
+      "| 14    | -0.11712 |  -0.11724 |   52.5      \n",
+      "| 15    | -0.11562 |  -0.11608 |   56.2      \n",
+      "| 16    | -0.11361 |  -0.11428 |   59.8      \n",
+      "| 17    | -0.11349 |  -0.11216 |   63.4      \n",
+      "| 18    | -0.11163 |  -0.11118 |   67.0      \n",
+      "| 19    | -0.11023 |  -0.11044 |   70.6      \n",
+      "| 20    | -0.11005 |  -0.11240 |   74.2      \n",
+      "| 21    | -0.10950 |  -0.11043 |   77.8      \n",
+      "| 22    | -0.10838 |  -0.11056 |   81.5      \n",
+      "| 23    | -0.10704 |  -0.10722 |   85.1      \n",
+      "| 24    | -0.10609 |  -0.10643 |   88.7      \n",
+      "| 25    | -0.10508 |  -0.10618 |   92.3      \n",
+      "| 26    | -0.10518 |  -0.10624 |   95.9      \n",
+      "| 27    | -0.10402 |  -0.10610 |   100.0     \n",
+      "| 28    | -0.10509 |  -0.10776 |   103.9     \n",
+      "| 29    | -0.10451 |  -0.10706 |   107.7     \n",
+      "| 30    | -0.10430 |  -0.10748 |   111.3     \n",
+      "| 31    | -0.10335 |  -0.10498 |   115.0     \n",
+      "| 32    | -0.10347 |  -0.10401 |   118.6     \n",
+      "| 33    | -0.10415 |  -0.10970 |   122.2     \n",
+      "| 34    | -0.10325 |  -0.10343 |   125.8     \n",
+      "| 35    | -0.10224 |  -0.10254 |   129.6     \n",
+      "| 36    | -0.10183 |  -0.10756 |   133.3     \n",
+      "| 37    | -0.10136 |  -0.10426 |   137.3     \n",
+      "| 38    | -0.10178 |  -0.10708 |   141.2     \n",
+      "| 39    | -0.10169 |  -0.10356 |   144.8     \n",
+      "| 40    | -0.10119 |  -0.10452 |   148.5     \n",
+      "| 41    | -0.10125 |  -0.10319 |   152.4     \n",
+      "| 42    | -0.10063 |  -0.10220 |   156.1     \n",
+      "| 43    | -0.10256 |  -0.10303 |   159.8     \n",
+      "| 44    | -0.10225 |  -0.10408 |   163.5     \n",
+      "| 45    | -0.10148 |  -0.10433 |   167.4     \n",
+      "| 46    | -0.10156 |  -0.10320 |   171.1     \n",
+      "| 47    | -0.10021 |  -0.10196 |   174.9     \n",
+      "| 48    | -0.09982 |  -0.10393 |   178.7     \n",
+      "| 49    | -0.09998 |  -0.10265 |   182.6     \n",
+      "| 50    | -0.10100 |  -0.10246 |   186.3     \n",
+      "| 51    | -0.09985 |  -0.10269 |   190.0     \n",
+      "| 52    | -0.10201 |  -0.10418 |   193.6     \n",
+      "| 53    | -0.10089 |  -0.10423 |   197.3     \n",
+      "| 54    | -0.09990 |  -0.10446 |   201.1     \n",
+      "| 55    | -0.10003 |  -0.10317 |   204.7     \n",
+      "| 56    | -0.09980 |  -0.10336 |   208.3     \n",
+      "| 57    | -0.09939 |  -0.10587 |   211.9     \n",
+      "| 58    | -0.09933 |  -0.10481 |   215.5     \n",
+      "| 59    | -0.09974 |  -0.10273 |   219.2     \n",
+      "| 60    | -0.09997 |  -0.10355 |   223.0     \n",
+      "| 61    | -0.09924 |  -0.10179 |   227.1     \n",
+      "| 62    | -0.09978 |  -0.10190 |   230.8     \n",
+      "| 63    | -0.09989 |  -0.10237 |   234.8     \n",
+      "| 64    | -0.09990 |  -0.10196 |   238.5     \n",
+      "| 65    | -0.09863 |  -0.10206 |   242.2     \n",
+      "| 66    | -0.09905 |  -0.10270 |   245.8     \n",
+      "| 67    | -0.09848 |  -0.10377 |   249.3     \n",
+      "| 68    | -0.10012 |  -0.10690 |   253.0     \n",
+      "| 69    | -0.10193 |  -0.10218 |   256.7     \n",
+      "| 70    | -0.09998 |  -0.10064 |   260.4     \n",
+      "| 71    | -0.09885 |  -0.10292 |   264.1     \n",
+      "| 72    | -0.09892 |  -0.10229 |   267.7     \n",
+      "| 73    | -0.09881 |  -0.10201 |   271.3     \n",
+      "| 74    | -0.09781 |  -0.10280 |   275.0     \n",
+      "| 75    | -0.09735 |  -0.10137 |   278.6     \n",
+      "| 76    | -0.09808 |  -0.10501 |   282.4     \n",
+      "| 77    | -0.09801 |  -0.10157 |   286.5     \n",
+      "| 78    | -0.09794 |  -0.10125 |   290.4     \n",
+      "| 79    | -0.09792 |  -0.10127 |   294.2     \n",
+      "| 80    | -0.10004 |  -0.10365 |   298.0     \n",
+      "| 81    | -0.09997 |  -0.10369 |   301.8     \n",
+      "| 82    | -0.09867 |  -0.10180 |   305.7     \n",
+      "| 83    | -0.09917 |  -0.10155 |   309.6     \n",
+      "| 84    | -0.09833 |  -0.10008 |   313.5     \n",
+      "| 85    | -0.09717 |  -0.10084 |   317.2     \n",
+      "| 86    | -0.09712 |  -0.10194 |   320.9     \n",
+      "| 87    | -0.09689 |  -0.10034 |   324.9     \n",
+      "| 88    | -0.09689 |  -0.09968 |   328.9     \n",
+      "| 89    | -0.09652 |  -0.10238 |   332.8     \n",
+      "| 90    | -0.09648 |  -0.10201 |   336.4     \n",
+      "| 91    | -0.09613 |  -0.10137 |   340.1     \n",
+      "| 92    | -0.09700 |  -0.10086 |   343.9     \n",
+      "| 93    | -0.09597 |  -0.10283 |   347.5     \n",
+      "| 94    | -0.09557 |  -0.10155 |   351.1     \n",
+      "| 95    | -0.09695 |  -0.10242 |   354.7     \n",
+      "| 96    | -0.09673 |  -0.10260 |   358.3     \n",
+      "| 97    | -0.09817 |  -0.10203 |   362.0     \n",
+      "| 98    | -0.09812 |  -0.10159 |   365.6     \n",
+      "| 99    | -0.09810 |  -0.10062 |   369.3     \n",
+      "| 100   | -0.09764 |  -0.10309 |   372.9     \n",
+      "| 101   | -0.09749 |  -0.10256 |   376.6     \n",
+      "| 102   | -0.09742 |  -0.10117 |   380.2     \n",
+      "| 103   | -0.09681 |  -0.10163 |   383.8     \n",
+      "| 104   | -0.09630 |  -0.10174 |   387.4     \n",
+      "| 105   | -0.09596 |  -0.10151 |   391.0     \n",
+      "| 106   | -0.09614 |  -0.10034 |   394.8     \n",
+      "| 107   | -0.09523 |  -0.10210 |   398.5     \n",
+      "| 108   | -0.09453 |  -0.09970 |   402.3     \n",
+      "| 109   | -0.09429 |  -0.10152 |   405.9     \n",
+      "| 110   | -0.09388 |  -0.10249 |   409.5     \n",
+      "| 111   | -0.09395 |  -0.10333 |   413.2     \n",
+      "| 112   | -0.09488 |  -0.10188 |   416.9     \n",
+      "| 113   | -0.09454 |  -0.10256 |   420.5     \n",
+      "| 114   | -0.09423 |  -0.10288 |   424.1     \n",
+      "| 115   | -0.09376 |  -0.10074 |   427.8     \n",
+      "| 116   | -0.09438 |  -0.10271 |   431.5     \n",
+      "| 117   | -0.09545 |  -0.10095 |   435.1     \n",
+      "| 118   | -0.09458 |  -0.10152 |   438.6     \n",
+      "| 119   | -0.09387 |  -0.10305 |   442.3     \n",
+      "| 120   | -0.09325 |  -0.10241 |   445.8     \n",
+      "| 121   | -0.09296 |  -0.10279 |   449.5     \n",
+      "| 122   | -0.09343 |  -0.10315 |   453.2     \n",
+      "| 123   | -0.09531 |  -0.10103 |   456.8     \n",
+      "| 124   | -0.09459 |  -0.10125 |   460.5     \n",
+      "| 125   | -0.09273 |  -0.10181 |   464.2     \n",
+      "| 126   | -0.09285 |  -0.10089 |   467.9     \n",
+      "| 127   | -0.09228 |  -0.10276 |   471.7     \n",
+      "| 128   | -0.09285 |  -0.10120 |   475.4     \n",
+      "| 129   | -0.09184 |  -0.10286 |   479.1     \n",
+      "| 130   | -0.09256 |  -0.10405 |   482.9     \n",
+      "| 131   | -0.09177 |  -0.10313 |   486.5     \n",
+      "| 132   | -0.09206 |  -0.10276 |   490.1     \n",
+      "| 133   | -0.09148 |  -0.10407 |   493.8     \n",
+      "| 134   | -0.09167 |  -0.10524 |   497.5     \n",
+      "| 135   | -0.09093 |  -0.10417 |   501.1     \n",
+      "| 136   | -0.09172 |  -0.10197 |   504.8     \n",
+      "| 137   | -0.09049 |  -0.10340 |   508.5     \n",
+      "| 138   | -0.09086 |  -0.10326 |   512.2     \n",
+      "Early stopping occured at epoch 138\n",
+      "Training done in 512.241 seconds.\n",
+      "---------------------------------------\n"
+     ]
+    }
+   ],
    "source": [
     "clf.fit(\n",
     "    X_train=X_train, y_train=y_train,\n",
@@ -193,28 +580,31 @@
     "    max_epochs=max_epochs,\n",
     "    patience=50,\n",
     "    batch_size=1024, virtual_batch_size=128,\n",
-    "    num_workers=0,\n",
-    "    drop_last=False\n",
     ") "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BEST VALID SCORE FOR census-income : 0.0996807\n",
+      "FINAL TEST SCORE FOR census-income : 0.100988\n"
+     ]
+    }
+   ],
    "source": [
-    "# Deprecated : best model is automatically loaded at end of fit\n",
-    "# clf.load_best_model()\n",
-    "\n",
+    "# Best model is automatically loaded at end of fit\n",
     "preds = clf.predict(X_test)\n",
     "\n",
-    "y_true = y_test\n",
+    "test_score = mean_squared_error(y_pred=preds, y_true=y_test)\n",
     "\n",
-    "test_score = mean_squared_error(y_pred=preds, y_true=y_true)\n",
-    "\n",
-    "print(f\"BEST VALID SCORE FOR {dataset_name} : {clf.best_cost}\")\n",
-    "print(f\"FINAL TEST SCORE FOR {dataset_name} : {test_score}\")"
+    "print(f\"BEST VALID SCORE FOR {dataset_name} : {clf.best_cost:.6}\")\n",
+    "print(f\"FINAL TEST SCORE FOR {dataset_name} : {test_score:.6}\")"
    ]
   },
   {
@@ -226,11 +616,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([3.25987229e-06, 5.63586695e-03, 1.21311484e-03, 1.26350003e-02,\n",
+       "       1.27364044e-01, 5.38086823e-02, 1.52821290e-01, 1.89732903e-01,\n",
+       "       2.07340671e-04, 7.46324999e-03, 2.67158208e-01, 1.47141967e-01,\n",
+       "       0.00000000e+00, 3.48150732e-02])"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "clf.feature_importances_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "capital_gain      0.267158\n",
+       "relationship      0.189733\n",
+       "occupation        0.152821\n",
+       "capital_loss      0.147142\n",
+       "education_num     0.127364\n",
+       "marital_status    0.053809\n",
+       "native_country    0.034815\n",
+       "education         0.012635\n",
+       "sex               0.007463\n",
+       "workclass         0.005636\n",
+       "fnlwgt            0.001213\n",
+       "race              0.000207\n",
+       "age               0.000003\n",
+       "hours_per_week    0.000000\n",
+       "dtype: float64"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "important_features = pd.Series(data=clf.feature_importances_,index=train.columns[:-2])\n",
+    "important_features.sort_values(ascending=False,inplace=True)\n",
+    "\n",
+    "display(important_features.sort_values(ascending=False))"
    ]
   },
   {
@@ -242,7 +682,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +691,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,9 +701,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABGYAAARuCAYAAACRGjGeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nOzde5TfdX3n8fcnmZAgEEiAAEOAcAtXNSpy09rdohura/GsyzlVV7F1pdRWu27bXUQ9vRxP0fZYd61rV60K7Kor1hveGiluq0ICCTVyUe4GAiFBIYEQIdfP/pEfJ1nM/JIw38+8fzPzeJzjSeaS13wyJ84nPv0mKbXWAAAAAGDsTck+AAAAAMBkJcwAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhhgmrlPKvSikPZJ8DgMHkngCgH/cEY0WYgZ5SyhtKKfeVUjaUUr5aSpmdfSYABkMp5YhSytWllFWllFpKmZd9JgAGRynl1aWUH5RS1pVSVpdSPllKOSD7XIwPwgxERCnltIj4eES8KSIOi4hfRMTHUg8FwCDZFhH/EBGvyz4IAAPpwIh4f0QMR8QpETE3Iv4q9USMG8IMKUopK0opf1xKubn3hMqnSimHlVK+XUpZX0r5x1LKrJ3e/4u98vxYKeV7vZDy9NteVUr5ce/HPVhK+aMRPuY7e+83dxdvfmNEfL3W+r1a6xMR8b6I+HcqN0COQbsnaq1raq0fi4ilTX7CAOyVAbwnPldr/Yda6y9qrWsj4pMR8ZIWP3cmHmGGTK+LiFdExPyIeE1EfDsiLo2IQ2L7r8137vS+346IEyNiTkT8S0R8dqe3fSoifqfWekBEnB4R333mByqlvC8i3hIRv1pr3dWfEz0tIn709Au11nsiYlPvbADkGKR7AoDBM8j3xMsi4ra9++kwWQ1lH4BJ7W9qrWsiIkop34+Ih2utP+y9/JWIOO/pd6y1fvrp75dS/jQi1pZSDqy1PhYRmyPi1FLKj3p1eu1OH6OUUv46Is6MiH/de/9d2T8invm2xyLCEzMAeQbpngBg8AzkPVFKeUVEXBgRZ432J8jk4IkZMq3Z6ftP7uLl/SMiSilTSykfKKXcU0p5PCJW9N7nkN63r4uIV0XEfaWUfy6lnLPTzkERcVFEXLabL6JPRMTMZ7xuZkSs34ufDwDdGqR7AoDBM3D3RCnl7Ij4XET8+1rrnc/i58QkJMwwHrwhIs6PiJfH9r9Ua17v9SUiota6tNZ6fmx/LPGrEXHVTj92bUT824j4TCml35/xvC0inv/0C6WU4yJiekT4Ygow+MbingBg/BqTe6KU8oKIuDoifrvWem2XPwEmNmGG8eCAiNgYEY9ExHMi4i+efkMpZZ9Syht7jyFujojHI2Lrzj+41vpPsf0v9/1KKWWkxwk/GxGvKaX8Sillv4j484j4cq3VEzMAg28s7okopcyI7dE+ImJ672UABl/ze6KUcnps/9f73lFr/XqTnwUTljDDeHBlRNwXEQ9GxI8jYskz3v6miFjReyzx4oj4D88cqLVeExG/FRFXl1JetIu339b7sZ+NiIdj+xfvt3f4cwCgneb3RM+Tsf2PvkZE3N57GYDBNxb3xB9GxKER8alSyhO9//jLf9kjpdaafQYAAACASckTMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQZGgsP9g+ZXqdEfuN5YccOGXfGU1265NPNdlt5ZDTN3a++fNbp3e+CU97KjbEprqxZJ9jonNPtLNpuM3ndZ9VG5rsMv5sPOY5nW9Ov+8XnW+24p4YG+4JWtp4VJtfW9NXjq+7cuPcRp+HB8bX56Fr/e6JMQ0zM2K/OKucN5YfcuBMmX9yk91tN9/eZLeV3/ryfZ1vfuakYzrfhKfdUK/NPsKk4J5oZ8XvndNkd957FzfZZfy58z0v7nxz/u8s7XyzFffE2HBP0NJdf3x2k90T/2BJk91W7nlXm8/D8X80vj4PXet3T/ijTAAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQZFRhppTyylLKHaWUu0spl3R1KAAmBvcEAP24JwBGEWZKKVMj4n9ExK9HxKkR8fpSyqldHQyA8c09AUA/7gmA7UbzxMyZEXF3rfXeWuumiPg/EXF+N8cCYAJwTwDQj3sCIEYXZo6MiJU7vfxA73X/n1LKRaWUZaWUZZtj4yg+HADjjHsCgH7cEwAxujBTdvG6+kuvqPUTtdYzaq1nTIvpo/hwAIwz7gkA+nFPAMTowswDEXHUTi/PjYhVozsOABOIewKAftwTADG6MLM0Ik4spRxbStknIn4zIq7u5lgATADuCQD6cU8ARMTQs/2BtdYtpZTfj4hFETE1Ij5da72ts5MBMK65JwDoxz0BsN2zDjMREbXWb0XEtzo6CwATjHsCgH7cEwCj+6NMAAAAAIyCMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSjOpfZRoUQ0cc3vnmlodWd74ZEbHt5tub7Lay8r3nNtn9zEndbw7NO7r70YjYsuL+Jru088C7u/91u/nTSzrfhLE0/P3N2UfYK/d/8bmdbx59wS2db7LD/E89lX0EgFE56ppt2UcYCOe97EdNdlc0WZ0YPDEDAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSDGUfoAtbHlqdfYQJ66j3X99kd9Gq5Z1vLhzufJJxau5l3f+6fbBu6HwTxtKql01rsjtvUZPZOPqCW9oM08ydv71v55vzb+x8EmBEK3+9NNk98RtNZpv57ncXNNk9LhY32Z0IPDEDAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYayDzConlx0bJPdfRf+tMnuePPi9/5u55uzY3HnmwATxdHfeSr7CHvl7v/1gs43T3jTDzvfZIdjrq7ZRwAYlfmffqLJ7nj76njJ+V9psnvVJYc32Z0IPDEDAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYayDzCo9l340+wjTGhf+tO/6nzz4q+8pvPNiIita9c22QUYS1unT22y2+r/4dn2pN+ijDd1ask+AsCobDp43ya705qstnP7k0c0Wq6Ndsc/T8wAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAkqHsAzA5HT20f+ebW9eu7XwTYKKYce8jTXa3NlmNmDHrqUbLtLL5Od3//30zOl8ExtqiVcub7C4cXtD55rTvLOt8czy6+YU1+wiTjidmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIMlQ9gGYnBYOL+h8c9Gq5Z1vRrQ5K8BI2n0tazLbzNEX3JJ9BPbSAV9Ykn0EYACNp99LDx03r8nulntXNNlt5d333Nxk97Ljn9dkdyLwxAwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgylH2AyeZnV5/UZPfQ37ijye7Q3COb7K47Z27nmwuHO58EGHMLhxc02X389Wc32Z35+SVNdle/69zONw//8PWdb7LDzy4+p/PNQ//n4s43AUay6pVt/gfFnI+taLLbyn++7YImu4dGm//NOhF4YgYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSDGUfYLI59DfuyD7CXtnywINNdq/779/sfHPhFxd0vgkwUTx6emmyO7PJasThH76+0TKtrF2wtfPNQztfBBjZY6d1/3UsImJOk9V21v94dpNdX9NH5okZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASDKUfQAG29DcI5vsLhzufvMvfnpj96MRcemxZzbZBdiVRauWN9lt8XUXdjb/4jb3MMBYOeVDa5rsbmmy2s4nL/h4k93LLnlek92JwBMzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkGQo+wCTzeOvP7vJ7szPL2myW/ed3mR3xRee1/nmpcd2Pgkw5hYOL2iyu+ad5zbZPewj1zfZZfzZ+OoXd745/ZtLO9+MiFj1X7r/78PmK9r8XgwYO5uGD2qyO+XeJrPN3PCL47OPMOl4YgYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkuw0zpZRPl1IeLqXcutPrZpdSriml3NX7dlbbYwIwqNwTAPTjngDob0+emLk8Il75jNddEhHX1lpPjIhrey8DMDldHu4JAEZ2ebgnAEa02zBTa/1eRDz6jFefHxFX9L5/RUS8tuNzATBOuCcA6Mc9AdDfs/07Zg6rtT4UEdH7ds5I71hKuaiUsqyUsmxzbHyWHw6AccY9AUA/7gmAnuZ/+W+t9RO11jNqrWdMi+mtPxwA44x7AoB+3BPARPdsw8yaUsoRERG9bx/u7kgATADuCQD6cU8A9DzbMHN1RFzY+/6FEfG1bo4DwAThngCgH/cEQM+e/HPZn4+IxRFxUinlgVLKWyPiAxHxilLKXRHxit7LAExC7gkA+nFPAPQ3tLt3qLW+foQ3ndfxWQAYh9wTAPTjngDor/lf/gsAAADArgkzAAAAAEmEGQAAAIAkwgwAAABAkt3+5b90a+Y9G7KPsFde/bWlTXavPvXgJrsA7Nrhi9c32a1NViP2/efDOt988lfXdL7JDs+5d13nm1s7X9xu+C+v73xzZR1fv8cDftkTR81osjuzyWo71z16fKPl1Y12xz9PzAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAECSoewDdGHtW87pfHPW5Ys734yIiBtvabPbyNWnHtxkd9uvvKDzzSnf/2Hnm4xPd3/47M43N35oSeebMJY2z9ynyW6r30jcsnK4880TYk3nm+ywcXhm55tDP+l8EmBEs69/sMnuliarEX92701Ndv/kuBc12WVknpgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJEPZB+jCrMsXZx9hwtr20gVNdl/+sR90vvnd5+7X+Sbj0wnvWtL55iN1Q+ebMJbWH7VPk91ZTVYj9l+6b6NlWnn8mO5/jc3ufBFgZE8894gmuzPuW9lk90+Oe1GT3Xk3trmDV5z5ZJPdicATMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBkKPsAk82mhWc02d1n0bI2u/f9vMnuPz58cuebU2Jl55sAE8X6o0uT3VlNViPmfum+zje3dL7Iztae0v3m7O4nAUb00EunNtk99htNZpv5zrLnNtmdHzc22Z0IPDEDAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSDGUfYLJ5fN60JruHNFmNePC1RzfZPey86zvfXPfmczrfjIg46MrFTXYBxtK8rz7aZHdbk9WIOX//eOebq87ufJKdzP/kw51vbu18EWBkx14yvn7fv2jV8ia7C4ebzNKHJ2YAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgyVD2ASabR8/Y0mT3kI83mY3hK25tsnvfu8/tfHPuZdd3vgkwUax+6ewmu3NubjIbP/noaZ1vHhhLOt9kh4f+zWGdb865857ONwFGsu7N5zTZPejKxU12Fw4vaLK77dqjmuxOOW9lk92JwBMzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkGQo+wCTzfy3Lc0+wl7Z+vjjTXZve8fHOt9ceNmCzjcBJoqnDs0+wd458H8vyT4Ce2ndCzd1vjmn80WAka0/pjTZPajJajv3rGzz1ffEWNlkdyLwxAwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkGco+AIPtzr89s8nu8//y3M435857oPPNiIgtK+5vsgswluZ+98nsI+yVez+3oPPN496wvPNNdpj3hewTAIzO0d96rMlubbLaznvO+maT3avi8Ca7E4EnZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQJKh7AMw2E659K4mu1vXru1882/v/0HnmxERbzv6pU12AXZl0arlTXYXDjeZbea4N7T5PNDOPouWZR8BYFTK1tpkt81qO9PKluwjTDqemAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkQ9kHYLBtXbu2ye5Fd97b+ebbjn5p55uMT1NPO6nzzXL3DzrfhF1ZOLygyW59SZvdct3yJruzrpvd+ebalzza+SY7DB1zVOebW+5b2fkmwEi2HDC9ye54exrigU0HZx9h0hlvv0YAAAAAJgxhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASXYbZkopR5VS/m8p5SellNtKKX/Qe/3sUso1pZS7et/Oan9cAAaNewKAftwTAP3tyRMzWyLiD2utp0TE2RHxe6WUUyPikoi4ttZ6YkRc23sZgMnHPQFAP+4JgD52G2ZqrQ/VWv+l9/31EfGTiDgyIs6PiCt673ZFRLy21SEBGFzuCQD6cU8A9LdXf8dMKWVeRLwgIm6IiMNqrQ9FbP9iGxFzRvgxF5VSlpVSlm2OjaM7LQADzT0BQD/uCYBftsdhppSyf0R8KSL+U6318T39cbXWT9Raz6i1njEtpj+bMwIwDrgnAOjHPQGwa3sUZkop02L7F9HP1lq/3Hv1mlLKEb23HxERD7c5IgCDzj0BQD/uCYCR7cm/ylQi4lMR8ZNa61/v9KarI+LC3vcvjIivdX88AAadewKAftwTAP0N7cH7vCQi3hQRt5RSlvded2lEfCAiriqlvDUi7o+IC9ocEYAB554AoB/3BEAfuw0ztdYfREQZ4c3ndXscAMYb9wQA/bgnAPrbq3+VCQAAAIDuCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgyZ78c9kDb+1bzul8c9blizvfZIdPzD8u+whMYE/+t6c639z29tr5JoylTQdNa7I7vclqxNIb5ne+eUIs6XyTHdaddWTnm/vft7LzTYCRrDthRpPd2d9vMtvMd1af0mR3eqxosjsReGIGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkgxlH6ALsy5fnH2EPVaG2nzK65YtTXbv+uhZTXYPvbH7Jnjwt+/ufDMiYuvPftZkl3b2/d3uf31Nub/zSRhT+6zdlH2EvTLz+HXZR2Av7ffgU9lHABiVg299oslubbLazm/OXdpk9ytxaJPdicATMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIMlQ9gEmmzLU5lNet2xpsnvK+1c02b30+m93vvnnV76w803Gp613/7TzzVo3db4JY+mBX9uvye5R1zeZjSMufKjzza2dL7Kzu964T+eb86/rfBJgRCtes3+T3WOWNplt5oPXvarJ7vwYZ5+IMeSJGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgylH2AQTVlv/2a7G7bsKHJbitbVq9psnvitCeb7AKwa5tn1uwj7JWt6x7LPgJ7qWwt2UcAGJWhDb6ORUQM7bc5+wiTjidmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIMlQ9gEG1bYNG7KPMBCmHnJwk93122qTXQB2bdr6kn2EvTLlgAM639y2fn3nm+xQp7nbgfFt6sbsEwyGfaZvzj7CpOOJGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgifmuhAIAAB6iSURBVDADAAAAkESYAQAAAEgylH2AyWbqSSc02d16x91tdn/+SJPdtx/z0s4333n37Z1vRkR85ISTm+wC7MqiVcub7C4cbjLbzLb167OPwF6af/GN2UcAGJVDbtmYfYSBcP5xtzTZvclzISPymQEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmGsg8wqKbst1+T3a133N1kt5WNr3pxk93h93T/efjICSd3vgkw1hYOL2iy+8h/PKfJ7sF/t7jJLuNPOeP0zjfrsls734yIuOtvzup8c+MHl3S+CYytaeuearJbm6y2c/yMh5vs3hSHN9mdCDwxAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmGsg8wqLZt2NBkt7zotCa79abbmuxO/9bSJrvnfWh155tXxeGdbwJMFOtOrk12D26yynh055v273zzxGWdT27ffccNnW8+Wtv83hEYOw+ed2CT3eGbmsw288HlC5vsHhs/arI7EXhiBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIMZR9gsqk33ZZ9hIHw1gNXd755VRze+SbARDF1Y8k+AhNcnb4t+wgAo7Lh6K3ZRxgI9f7nZB9h0vHEDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQZyj7ApDNlapvdbVubzE45/eQmuwuHu9988x0rux+NiCtPOqrJLsCuLFq1vMlui6+7sLP5F9+YfQSAUTnp79Y32d3WZLWd953/xSa7n/2vc5vsTgSemAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQJLdhplSyoxSyo2llB+VUm4rpfxZ7/WzSynXlFLu6n07q/1xARg07gkA+nFPAPS3J0/MbIyIX6u1Pj8iFkTEK0spZ0fEJRFxba31xIi4tvcyAJOPewKAftwTAH3sNszU7Z7ovTit958aEedHxBW9118REa9tckIABpp7AoB+3BMA/e3R3zFTSplaSlkeEQ9HxDW11hsi4rBa60MREb1v57Q7JgCDzD0BQD/uCYCR7VGYqbVurbUuiIi5EXFmKeX0Pf0ApZSLSinLSinLNsfGZ3tOAAaYewKAftwTACPbq3+Vqda6LiL+KSJeGRFrSilHRET0vn14hB/ziVrrGbXWM6bF9FEeF4BB5p4AoB/3BMAv25N/lenQUspBve/vGxEvj4jbI+LqiLiw924XRsTXWh0SgMHlngCgH/cEQH9De/A+R0TEFaWUqbE95FxVa/1GKWVxRFxVSnlrRNwfERc0PCcAg8s9AUA/7gmAPnYbZmqtN0fEC3bx+kci4rwWhwJg/HBPANCPewKgv736O2YAAAAA6I4wAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJdvvPZdOtoTmHNNndsnpNk91tt97eZPeBd5/b+eaVJ13f+Sbj010fPavzzY0fXNL5JuzKwuEFTXYf/v3uv+5GRMz5aJuvvU+95szON2d8/cbON9nhwUu6/zV25Afc7cDYWXfKzCa7M5c3mW3m79ec0Wh5daPd8c8TMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAD8v/buPcjPsjrg+HmSDaCUi04FWRJYlCDibVHEgFNttcxStIKdTkcHlFZnOs5oC7aDwmgvSltt7VB7sToMRVBTHIt2vFSNCF46JSAkRKqGEioIMSTBC4JAIZenf+SniXF3szHvs+f37n4+M052d8LJGfhlz+brmwQAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASUayF5hvtm7clL3CXimL9msy96Y3vrfzma9818mdz6Sflr7pxs5n/qA+1PlMmE0/XlybzD2sydSIAz79tUaTaeXhJduyVwDYJ987sTSZe/BVTcY2841bj24yd2lsbDJ3LvDEDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQZyV5gvllw0EFN5m5/8MEmc+uWx5rMfeXikzuf+Z67buh8ZkTEBWPLmsylnQUHHtj5zPKwjs3sWLFhTZO5E6NNxsJPLX3jjdkrAOyTpVd8v8ncbU2mtnPJ6cubzH1/HNtk7lzgVxoAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQZCR7gflm+4MPZq8wZz17vwOyV2BIbH/ooc5n1rq985kwmTOOf1GTuQsev7XJ3O0PP9xk7nvuuqHzmReMLet8JgBzR/nhA9krDIWnLPpeo8nHNprbf56YAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCQj2QswP63YsKbzmROj453PBJht2x54oMncu/7ylCZzx962ssncC8aWNZlLO7d/4OTOZx73hq91PhNgKmsvHGsyd+l5G5vMbeW3rj6/ydynxg1N5s4FnpgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJRrIXAADaW/LFR7NX2Cv/u/zEzmc+9exbOp/JTsdcvS17BYB9csg6zy1ERBx47I+yV5h3vPIAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgyUj2AvNNWbRfk7l1y2NN5i58xtOazJ0Y7X7m2bet735oRCw/fnGTuQCTedxXDm8y95EXr24yt5XDPr1/9grspUVfXJW9AsA+OeLz9zaZu63J1HYuedbHmsz9m3hWk7lzgSdmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIMlI9gLzzYZ/e2qTuUectbbJ3LqwNJnbwuVvfmWTufvHTU3mAkzmkRdvajJ3+6+c2GTugv+8pcnc+3/7x53PPOijnY9kF9tf3P1rbMFX2ry+ACaz9fBDmswtdzQZ28zqR8ayV5h3PDEDAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASUayF5hvjjhrbfYKe+Xbv/OEJnPHbu1+5nfO6n5mRMRxn2szF2A2Lbr9u03mbmsyNeLjJ13a+czz49TOZ7LTgq/ckr0CwD4p/7Ume4W9smJDm30nRsebzGVqnpgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJRrIXYLiNvX1lk7krNqzpfObEaOcjAeaMO99wbJO5R71jc5O554+d2mQu7dx++UmdzzzudTd3PhNgKvf8SZvbs+Ti65vMnRgdbzJ33RXPazJ36e+uajJ3LvDEDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAElmHGZKKQtLKbeUUj4zeP+JpZRrSinrBt8+od2aAAw7dwKAqbgRAFPbmydmzouItbu8f2FEXFtrXRoR1w7eB2D+cicAmIobATCFGYWZUsriiHhZRFy2y4fPjIgrB29fGRFndbsaAH3hTgAwFTcCYHozfWLmvRHxlojYvsvHDq+13hsRMfj2sMn+wVLK75dSbi6l3LwlHt2nZQEYWu4EAFP5hW9EhDsBzH17DDOllJdHxOZa66pf5AeotV5aaz2p1nrSotj/FxkBwBBzJwCYyr7eiAh3Apj7RmbwfV4YEa8opZwREQdExMGllI9ExKZSyhG11ntLKUdExOaWiwIwtNwJAKbiRgDswR6fmKm1XlRrXVxrHYuIV0XEdbXWcyLiUxFx7uC7nRsRn2y2JQBDy50AYCpuBMCe7c3fyrS7d0fEaaWUdRFx2uB9APgJdwKAqbgRAAMz+a1MP1Vr/XJEfHnw9vcj4qXdrwRAX7kTAEzFjQCY3L48MQMAAADAPhBmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQJK9+luZmH9WbFjTZO7E6HiTuQBM7uj/eKDJ3NpkasRRNx7Y+cy7X/BQ5zPZ6YR3bOp85tbOJwJMbcnF12evsFfa/VqtyVim4YkZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASDKSvQDDbWJ0vMncu//01M5nHvXO6zufST/d/sHndT7z0T9f2flMmE2bn39Qk7lPurnJ2Fj3jhM6n7l/3NT5THa687VLOp+55OJ7Op8JMJX1F3X/a5SIiMXvavPrlFa/VrvjIyc2mXvsObc0mTsXeGIGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkoxkL8D8dNQ7r+985ooNazqfGRExMTreZC7tHPd7qzqf+cP6cOczYTILDz64ydzDr/x6k7nbm0yN+Id//sfOZ14wtqzzmey05OLubzvAbDr645uazN3WZGo771v2r03m/l08vcncucATMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIMlI9gIAwE6fve2rTeZOjI43mdvKBWPLslcAYJ557MhDmsxdeHuTsc2sfOjY7BXmHU/MAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQJKR7AW6cP9rTul85qEfXtn5TNqaGB3PXoFhce3i7me+YVH3M2ESrT6X/d9vntxk7gGf/lqTuXf9Rfe3feztbntL97+2wddjH/LfDPpuxYY1Tea2uJcLv7S685l9dMNzfN072zwxAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAElGshfowqEfXpm9AkPgr++8scnctx7zgiZzaWfktds7n1k2dT4SJrViw5omcydGm4xtZuztbnvfHPoh/82AnzcxOp69wowtGD+hydzta77VZG4rZ9+2vsnc5ccvbjJ3LvDEDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQZyV6A4fboGc9vMve752zpfOZbj+l8JD215egndT6z/tCnS2bHxOh4k7nbfvW5TeYu/PLqJnPvvOo5nc885tVf73wmO219yfM6nzly3arOZwJMpS4s2SsMhS3V172zzRMzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgyUj2AvPNyJMPbzJ368ZNTebu/9mbmsx9yme7n3nJXSu7HxoRfzR2SpO5tFOu/3r3Q+sj3c+EWbTf2vVN5m5rMjXik6e8v/OZ58epnc9kp5HrVmWvALBP6qpvZq8wFF5/yMYmcz8WT24ydy7wxAwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCTCDAAAAEASYQYAAAAgiTADAAAAkESYAQAAAEgizAAAAAAkGcleYL7ZunFT9gpz1jP2e1z2CgD7bMWGNU3mToyON5nbyvljp2avAMA8s+3Xnttk7sIvrW4yt5U/u+8Z2SvMO56YAQAAAEgizAAAAAAkEWYAAAAAkggzAAAAAEmEGQAAAIAkwgwAAABAEmEGAAAAIIkwAwAAAJBEmAEAAABIIswAAAAAJBFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASCLMAAAAACQRZgAAAACSCDMAAAAASYQZAAAAgCSl1jp7P1gp90XEd2b43X85Ir7XcJ0u9WnXiH7t26ddI/q1b592jcjf9+ha65MSf/x5wZ0YGn3at0+7RvRr3z7tGpG/rzsxC9yJodGnffu0a0S/9u3TrhH5+055J2Y1zOyNUsrNtdaTsveYiT7tGtGvffu0a0S/9u3TrhH925f2+vSa6NOuEf3at0+7RvRr3z7tGtG/fWmvT6+JPu0a0a99+7RrRL/27dOuEcO9r9/KBAAAAJBEmAEAAABIMsxh5tLsBfZCn3aN6Ne+fdo1ol/79mnXiP7tS3t9ek30adeIfu3bp10j+rVvn3aN6N++tNen10Sfdo3o17592jWiX/v2adeIId53aP+MGQAAAIC5bpifmAEAAACY04YuzJRSTi+l/E8p5Y5SyoXZ+0ynlLKklPKlUsraUso3SynnZe+0J6WUhaWUW0opn8neZU9KKYeWUq4updw2+Hd8SvZOUymlvHnwGvhGKeWqUsoB2TvtqpRyeSllcynlG7t87ImllGtKKesG3z4hc8efmGLX9wxeB7eWUv69lHJo5o7kcifacifacCe6406wJ+5EW+5EG+5Ed/p4J4YqzJRSFkbE+yLiNyLihIh4dSnlhNytprU1Iv641vr0iFgWEW8c8n0jIs6LiLXZS8zQ30fE52utx0fEc2JI9y6lHBkRfxgRJ9VanxkRCyPiVblb/ZwrIuL03T52YURcW2tdGhHXDt4fBlfEz+96TUQ8s9b67Ii4PSIumu2lGA7uxKxwJzrmTnTuinAnmII7MSvciY65E527Inp2J4YqzETEyRFxR63127XWxyLioxFxZvJOU6q13ltrXT14+8HY8RP9yNytplZKWRwRL4uIy7J32ZNSysER8aKI+JeIiFrrY7XW+3O3mtZIRDyulDISEY+PiA3J+/yMWutXI+IHu334zIi4cvD2lRFx1qwuNYXJdq21fqHWunXw7g0RsXjWF2NYuBMNuRNNuRMdcSfYA3eiIXeiKXeiI328E8MWZo6MiHt2eX99DPEnpl2VUsYi4sSIuDF3k2m9NyLeEhHbsxeZgadExH0R8cHBo5KXlVIOzF5qMrXW70bE30bE3RFxb0T8qNb6hdytZuTwWuu9ETu+KIiIw5L3manXRcTnspcgjTvRljvRgDsx69yJ+c2daMudaMCdmHVDdyeGLcyUST429H9tVCnllyLi4xFxfq31gex9JlNKeXlEbK61rsreZYZGIuK5EfH+WuuJEfFQDM+jcT9j8Hspz4yIYyJiNCIOLKWck7vV3FRKeVvseOR3efYupHEnGnEn2nEnZo87QbgTzbgT7bgTs2dY78SwhZn1EbFkl/cXx5A9wrW7Usqi2PFJdHmt9RPZ+0zjhRHxilLKXbHjkc6XlFI+krvStNZHxPpa60/+H4OrY8cn1mH06xFxZ631vlrrloj4REScmrzTTGwqpRwRETH4dnPyPtMqpZwbES+PiLNrrUP/BRbNuBPtuBPtuBOzwJ1gwJ1ox51ox52YBcN8J4YtzNwUEUtLKceUUvaLHX/g0aeSd5pSKaXEjt+zuLbWekn2PtOptV5Ua11cax2LHf9er6u1Dm2FrbVujIh7SilPG3zopRHxrcSVpnN3RCwrpTx+8Jp4aQzpHyy2m09FxLmDt8+NiE8m7jKtUsrpEfHWiHhFrfXh7H1I5U404k405U405k6wC3eiEXeiKXeisWG/E0MVZgZ/GM+bImJF7HghfqzW+s3crab1woh4TeyoxWsG/zsje6k55A8iYnkp5daIGI+Iv0reZ1KDCn91RKyOiP+OHT+vLk1dajellKsiYmVEPK2Usr6U8vqIeHdEnFZKWRcRpw3eTzfFrv8UEQdFxDWDn2cfSF2SNO4Eu3EnOuJOMFe4E+zGneiIO9FWGbIneAAAAADmjaF6YgYAAABgPhFmAAAAAJIIMwAAAABJhBkAAACAJMIMAAAAQBJhBgAAACCJMAMAAACQRJgBAAAASPL/KUBL44jyzDwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1440x1440 with 3 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, axs = plt.subplots(1, 3, figsize=(20,20))\n",
     "\n",
@@ -281,11 +734,48 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0]\tvalidation_0-rmse:0.47080\n",
+      "Will train until validation_0-rmse hasn't improved in 40 rounds.\n",
+      "[10]\tvalidation_0-rmse:0.33410\n",
+      "[20]\tvalidation_0-rmse:0.30905\n",
+      "[30]\tvalidation_0-rmse:0.30451\n",
+      "[40]\tvalidation_0-rmse:0.30464\n",
+      "[50]\tvalidation_0-rmse:0.30487\n",
+      "[60]\tvalidation_0-rmse:0.30534\n",
+      "[70]\tvalidation_0-rmse:0.30523\n",
+      "Stopping. Best iteration:\n",
+      "[34]\tvalidation_0-rmse:0.30411\n",
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "XGBRegressor(base_score=0.5, booster='gbtree', colsample_bylevel=1,\n",
+       "             colsample_bynode=1, colsample_bytree=1, gamma=0, gpu_id=-1,\n",
+       "             importance_type='gain', interaction_constraints=None,\n",
+       "             learning_rate=0.1, max_delta_step=0, max_depth=8,\n",
+       "             min_child_weight=1, missing=nan, monotone_constraints=None,\n",
+       "             n_estimators=1000, n_jobs=-1, num_parallel_tree=1,\n",
+       "             objective='reg:linear', random_state=0, reg_alpha=0, reg_lambda=1,\n",
+       "             scale_pos_weight=1, seed=0, silent=None, subsample=0.7,\n",
+       "             tree_method=None, validate_parameters=False, verbosity=0)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from xgboost import XGBRegressor\n",
     "\n",
@@ -297,7 +787,6 @@
     "    objective='reg:linear',\n",
     "    booster='gbtree',\n",
     "    n_jobs=-1,\n",
-    "    nthread=None,\n",
     "    gamma=0,\n",
     "    min_child_weight=1,\n",
     "    max_delta_step=0,\n",
@@ -307,8 +796,6 @@
     "    colsample_bynode=1,\n",
     "    reg_alpha=0,\n",
     "    reg_lambda=1,\n",
-    "    scale_pos_weight=1,\n",
-    "    base_score=0.5,\n",
     "    random_state=0,\n",
     "    seed=None,)\n",
     "\n",
@@ -319,18 +806,34 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
+   "source": [
+    "##### XGBoost model results evaluation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.09248\n",
+      "0.09244\n"
+     ]
+    }
+   ],
    "source": [
     "preds = np.array(clf_xgb.predict(X_valid))\n",
-    "valid_auc = mean_squared_error(y_pred=preds, y_true=y_valid)\n",
-    "print(valid_auc)\n",
+    "valid_mse = mean_squared_error(y_pred=preds, y_true=y_valid)\n",
+    "print(round(valid_mse,5))\n",
     "\n",
     "preds = np.array(clf_xgb.predict(X_test))\n",
-    "test_auc = mean_squared_error(y_pred=preds, y_true=y_test)\n",
-    "print(test_auc)"
+    "test_mse = mean_squared_error(y_pred=preds, y_true=y_test)\n",
+    "print(round(test_mse,5))"
    ]
   }
  ],
@@ -350,7 +853,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated census, regression notebooks. Proper variable names, better examples of categorical embedding dimensionality picking, added display of global feature importance, and column feature names. Also corrected incorrect score names in regression (output is MSE, not roc). 
Additionally, notebooks now include output of running them, making them much easier to view as examples online.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase.  -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


<!-- In addition to that please answer these questions: -->


**Closing issues**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
