### PR TITLE
Feat: add ReduceLROnPlateau support

### DIFF
--- a/pytorch_tabnet/tab_model.py
+++ b/pytorch_tabnet/tab_model.py
@@ -243,6 +243,12 @@ class TabModel(BaseEstimator):
             else:
                 self.patience_counter += 1
 
+            if self.scheduler is not None:
+                if isinstance(self.scheduler_fn, torch.optim.lr_scheduler.ReduceLROnPlateau):
+                    self.scheduler.step(stopping_loss)
+                else:
+                    self.scheduler.step()
+
             self.epoch += 1
             total_time += time.time() - starting_time
             if self.verbose > 0:
@@ -637,8 +643,6 @@ class TabNetClassifier(TabModel):
                          'stopping_loss': stopping_loss,
                          }
 
-        if self.scheduler is not None:
-            self.scheduler.step()
         return epoch_metrics
 
     def train_batch(self, data, targets):
@@ -894,8 +898,6 @@ class TabNetRegressor(TabModel):
                          'stopping_loss': stopping_loss,
                          }
 
-        if self.scheduler is not None:
-            self.scheduler.step()
         return epoch_metrics
 
     def train_batch(self, data, targets):


### PR DESCRIPTION
Enable use of lr_scheduler.ReduceLROnPlateau which requires a loss parameter during the step phase.
Change suggested - move scheduler.step() to outer training loop and add stopping_loss as parameter for case of ReduceLROnPlateau scheduler.

**What kind of change does this PR introduce?**
Enhancement

**Does this PR introduce a breaking change?**
Not to my best knowledge

**What needs to be documented once your changes are merged?**
indicate support for this scheduler in the documentation. This LR_scheduler can be very useful.

**Closing issues**
Closes #160 
