### PR TITLE
fix: support predict()ing on already-GPU Tensors

### DIFF
--- a/pytorch_tabnet/abstract_model.py
+++ b/pytorch_tabnet/abstract_model.py
@@ -207,7 +207,7 @@ class TabModel(BaseEstimator):
             PredictDataset(X),
             batch_size=self.batch_size,
             shuffle=False,
-            pin_memory=True
+            pin_memory=not (isinstance(X, torch.Tensor) and X.is_cuda)
         )
 
         results = []
@@ -241,7 +241,7 @@ class TabModel(BaseEstimator):
             PredictDataset(X),
             batch_size=self.batch_size,
             shuffle=False,
-            pin_memory=True
+            pin_memory=not (isinstance(X, torch.Tensor) and X.is_cuda)
         )
 
         res_explain = []

--- a/pytorch_tabnet/multitask.py
+++ b/pytorch_tabnet/multitask.py
@@ -97,7 +97,7 @@ class TabNetMultiTaskClassifier(TabModel):
             PredictDataset(X),
             batch_size=self.batch_size,
             shuffle=False,
-            pin_memory=True
+            pin_memory=not (isinstance(X, torch.Tensor) and X.is_cuda)
         )
 
         results = {}
@@ -145,7 +145,7 @@ class TabNetMultiTaskClassifier(TabModel):
             PredictDataset(X),
             batch_size=self.batch_size,
             shuffle=False,
-            pin_memory=True
+            pin_memory=not (isinstance(X, torch.Tensor) and X.is_cuda)
         )
 
         results = {}

--- a/pytorch_tabnet/tab_model.py
+++ b/pytorch_tabnet/tab_model.py
@@ -93,7 +93,7 @@ class TabNetClassifier(TabModel):
             PredictDataset(X),
             batch_size=self.batch_size,
             shuffle=False,
-            pin_memory=True
+            pin_memory=not (isinstance(X, torch.Tensor) and X.is_cuda)
         )
 
         results = []


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase.  -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Replace the hard-coded `pin_memory=True` with a dynamic check for whether `X` is a `torch.Tensor`, and if so whether it's a CUDA Tensor.

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?** bugfix

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?** No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

No doc changes as prediction function docstrings already claim that `torch.Tensor` inputs are supported... (Maybe this should be updated? It seems like the primary use case is actually numpy arrays...)

**Closing issues** #207

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
