### PR TITLE
feat: embedding-aware attention

### DIFF
--- a/pytorch_tabnet/abstract_model.py
+++ b/pytorch_tabnet/abstract_model.py
@@ -252,13 +252,9 @@ class TabModel(BaseEstimator):
 
             M_explain, masks = self.network.forward_masks(data)
             for key, value in masks.items():
-                masks[key] = csc_matrix.dot(
-                    value.cpu().detach().numpy(), self.reducing_matrix
-                )
+                masks[key] = value.cpu().detach().numpy()
 
-            res_explain.append(
-                csc_matrix.dot(M_explain.cpu().detach().numpy(), self.reducing_matrix)
-            )
+            res_explain.append(M_explain.cpu().detach().numpy())
 
             if batch_nb == 0:
                 res_masks = masks
@@ -481,13 +477,6 @@ class TabModel(BaseEstimator):
             mask_type=self.mask_type,
         ).to(self.device)
 
-        self.reducing_matrix = create_explain_matrix(
-            self.network.input_dim,
-            self.network.cat_emb_dim,
-            self.network.cat_idxs,
-            self.network.post_embed_dim,
-        )
-
     def _set_metrics(self, metrics, eval_names):
         """Set attributes relative to the metrics.
 
@@ -615,15 +604,12 @@ class TabModel(BaseEstimator):
 
         """
         self.network.eval()
-        feature_importances_ = np.zeros((self.network.post_embed_dim))
+        feature_importances_ = np.zeros((self.network.input_dim))
         for data, targets in loader:
             data = data.to(self.device).float()
             M_explain, masks = self.network.forward_masks(data)
             feature_importances_ += M_explain.sum(dim=0).cpu().detach().numpy()
 
-        feature_importances_ = csc_matrix.dot(
-            feature_importances_, self.reducing_matrix
-        )
         self.feature_importances_ = feature_importances_ / np.sum(feature_importances_)
 
     @abstractmethod


### PR DESCRIPTION
> ⚠️ **This is a pretty early draft with more testing required and feedback very welcome, and I know there's been some other work around here before e.g. #92 ...But I thought it was worth sharing early since I'd had some time to play, in case it's useful! **

This implementation amends the attention transformer output dimension to equal the *number of features*, instead of the number of post-embedding dimensions.

- `EmbeddingGenerator` is modified to keep a record of the number of dimensions that each feature was embedded to (in a deliberately agnostic way, because I've been experimenting with embedding scalar fields to multiple dimensions too).
- `TabNetNoEmbeddings` is modified to use this `feature_embed_widths` list to expand out the raw mask matrix `M` (by features) to the embedding-compatible `M_x` - by replicating each feature's mask weights to however many columns it was embedded to.
- Since all mask-based calcs are now at the feature level, rather than the embedding dimension level, I *think* the correct handling in `AbstractModel` is just to remove the `reducing_matrix` altogether? But should get more familiar with this area of the code.

**Important limitations:**

- Current implementation does not introduce embedding-aware attention as an option, but makes it **default and non-configurable** - so would be good to gather more data on the effectiveness/accuracy.
- So far only tested with basic `TabNetClassifier` fit & transform: As mentioned above I would need to drill further into the explainability to check there's no potential bugs introduced there. To my knowledge this change is agnostic to whether it's a regression or multi-task problem, but hopefully the CI tests will help confirm that 😂

**Testing and results:**

On a Forest Cover Type based example , I've observed this change to improve validation set performance from approx:

- **58.7% to 63.1%** at epoch 10 (faster convergence in early stages)
- **82.4% to 90.2%** at epoch 50 (still quite early on, but I haven't run any 200 epoch tests yet).

...at essentially the same training speed (11min 41sec to 50 epochs for both pre- and post-change algorithms).

Specifically:

- 80% training / 10% validation random split of Forest Cover Type (10% test set not yet used)
- `Area` and `Soil_Type` features consolidated from the raw (one-hot) data to categorical fields, with embedding dimensions 2 and 3 respectively (representing 4 distinct `Area`s, 40 `Soil_Types`)
- `batch_size=16384, clip_value=2.0, epsilon=1e-15, gamma=1.5, lambda_sparse=0.0001, lr=0.02, max_epochs=50, model_type='classification', momentum=0.3, n_a=64, n_d=64, n_independent=2, n_shared=2, n_steps=5, patience=100, seed=1337, target='Cover_Type', virtual_batch_size=256`


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase.  -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?** feature

<!-- E.g. a bugfix, feature, refactoring, build related change, etc… -->

**Does this PR introduce a breaking change?** ⚠️ Kinda

- The new embedding-aware attention behaviour is both default and non-configurable in the current implementation
- Some changes around 

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**What needs to be documented once your changes are merged?**

- Still need to check through READMEs, sample notebooks, etc for conflicting statements/guidance about how the attention & masking is implemented.

<!-- List all the information that needs to be added to the documentation after merge -->
<!-- When your changes are merged you will be asked to contribute this to the documentation -->

**Closing issues**

Hopefully #122, eventually