### PR TITLE
fix: load from cpu when saved on gpu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ data/
 .vscode/
 *.pt
 *~
+.vscode/
 
 # Notebook to python
 forest_example.py

--- a/pytorch_tabnet/abstract_model.py
+++ b/pytorch_tabnet/abstract_model.py
@@ -64,10 +64,10 @@ class TabModel(BaseEstimator):
         self.batch_size = 1024
         self.virtual_batch_size = 128
         torch.manual_seed(self.seed)
-        torch.manual_seed(self.seed)
         # Defining device
         self.device = torch.device(define_device(self.device_name))
-        print(f"Device used : {self.device}")
+        if self.verbose != 0:
+            print(f"Device used : {self.device}")
 
     def __update__(self, **kwargs):
         """
@@ -330,6 +330,7 @@ class TabModel(BaseEstimator):
             if self.network.state_dict().get(new_param) is not None:
                 # update only common layers
                 update_state_dict[new_param] = weights
+
         self.network.load_state_dict(update_state_dict)
 
     def save_model(self, path):
@@ -380,6 +381,7 @@ class TabModel(BaseEstimator):
             with zipfile.ZipFile(filepath) as z:
                 with z.open("model_params.json") as f:
                     loaded_params = json.load(f)
+                    loaded_params["device_name"] = self.device_name
                 with z.open("network.pt") as f:
                     try:
                         saved_state_dict = torch.load(f, map_location=self.device)
@@ -399,6 +401,7 @@ class TabModel(BaseEstimator):
         self._set_network()
         self.network.load_state_dict(saved_state_dict)
         self.network.eval()
+
         return
 
     def _train_epoch(self, train_loader):
@@ -539,7 +542,6 @@ class TabModel(BaseEstimator):
             epsilon=self.epsilon,
             virtual_batch_size=self.virtual_batch_size,
             momentum=self.momentum,
-            device_name=self.device_name,
             mask_type=self.mask_type,
         ).to(self.device)
 

--- a/pytorch_tabnet/pretraining.py
+++ b/pytorch_tabnet/pretraining.py
@@ -182,7 +182,6 @@ class TabNetPretrainer(TabModel):
             epsilon=self.epsilon,
             virtual_batch_size=self.virtual_batch_size,
             momentum=self.momentum,
-            device_name=self.device_name,
             mask_type=self.mask_type,
         ).to(self.device)
 

--- a/pytorch_tabnet/tab_network.py
+++ b/pytorch_tabnet/tab_network.py
@@ -298,7 +298,6 @@ class TabNetPretraining(torch.nn.Module):
         epsilon=1e-15,
         virtual_batch_size=128,
         momentum=0.02,
-        device_name="auto",
         mask_type="sparsemax",
     ):
         super(TabNetPretraining, self).__init__()
@@ -499,7 +498,6 @@ class TabNet(torch.nn.Module):
         epsilon=1e-15,
         virtual_batch_size=128,
         momentum=0.02,
-        device_name="auto",
         mask_type="sparsemax",
     ):
         """
@@ -538,7 +536,6 @@ class TabNet(torch.nn.Module):
             Batch size for Ghost Batch Normalization
         momentum : float
             Float value between 0 and 1 which will be used for momentum in all batch norm
-        device_name : {'auto', 'cuda', 'cpu'}
         mask_type : str
             Either "sparsemax" or "entmax" : this is the masking function to use
         """
@@ -580,15 +577,6 @@ class TabNet(torch.nn.Module):
             momentum,
             mask_type,
         )
-
-        # Defining device
-        if device_name == "auto":
-            if torch.cuda.is_available():
-                device_name = "cuda"
-            else:
-                device_name = "cpu"
-        self.device = torch.device(device_name)
-        self.to(self.device)
 
     def forward(self, x):
         x = self.embedder(x)

--- a/pytorch_tabnet/utils.py
+++ b/pytorch_tabnet/utils.py
@@ -311,5 +311,7 @@ def define_device(device_name):
             return "cuda"
         else:
             return "cpu"
+    elif device_name == "cuda" and not torch.cuda.is_available():
+        return "cpu"
     else:
         return device_name


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix when saving a model on GPU an loading on CPU.
To reproduce the bug on develop, use `device_name='cuda'` when defining the classifier on a GPU environment. Change to a CPU environment and try loading the model.

**Does this PR introduce a breaking change?**

No.

**What needs to be documented once your changes are merged?**

Nothing.

**Closing issues**
