### PR TITLE
Utils to format extraction of index and nunique of categorical columns

### DIFF
--- a/pytorch_tabnet/utils.py
+++ b/pytorch_tabnet/utils.py
@@ -294,3 +294,41 @@ def define_device(device_name):
             return "cpu"
     else:
         return device_name
+
+def get_idxs_dims(data, cat_cols=None):
+    """
+    Returns a dict containing the indexes and 
+    n_unique values of categorical columns
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+
+    cat_cols : list
+        List of column names of categorical values.
+        If None dtype object is used to guess the
+        categorical columns
+
+    Returns
+    -------
+    dict
+        {idx_nth0: dim_nth0, idx_nth1: dim_nth1, ...}
+        Dict with indexes of categorical columns as keys
+        and n_unique as values
+
+    Usage:
+    cat_dims = get_idxs_dims(df_train, cat_cols=categorical_features)
+
+    clf = TabNetClassifier(cat_idxs=[x for x, _ in cat_dims.items()],
+                           cat_dims=[x for _, x in cat_dims.items()],
+                          )
+    """
+    cat_idxs_dims = {}
+    
+    if cat_cols is None:
+        cat_cols = [col for col, dtype in zip(data.columns,
+                                              data.dtypes) if dtype == 'object']
+    for col in cat_cols:
+        cat_idxs_dims[data.columns.get_loc(col)] = data[col].nunique()
+
+    return cat_idxs_dims

--- a/pytorch_tabnet/utils.py
+++ b/pytorch_tabnet/utils.py
@@ -297,7 +297,7 @@ def define_device(device_name):
 
 def get_idxs_dims(data, cat_cols=None):
     """
-    Returns a dict containing the indexes and 
+    Returns a dict containing the indexes and
     n_unique values of categorical columns
 
     Parameters
@@ -324,7 +324,7 @@ def get_idxs_dims(data, cat_cols=None):
                           )
     """
     cat_idxs_dims = {}
-    
+
     if cat_cols is None:
         cat_cols = [col for col, dtype in zip(data.columns,
                                               data.dtypes) if dtype == 'object']


### PR DESCRIPTION
Implement auxiliary function to extract dict of indexes and unique values/dims

```
Usage:
    cat_dims = get_idxs_dims(df_train, cat_cols=categorical_features)

    clf = TabNetClassifier(cat_idxs=[x for x, _ in cat_dims.items()],
                                          cat_dims=[x for _, x in cat_dims.items()],
                                          )

maybe towards "cat_idxs and cat_dims are not required anymore"
    clf = TabNetClassifier(cat_cols=categorical_cols) 
```


**What kind of change does this PR introduce?**
Auxiliary function to allow internal/encapsulated extraction of indexes receiving only a list of categorical columns

**Does this PR introduce a breaking change?**
So far, nops

**What needs to be documented once your changes are merged?**
Please check comments in the code
