### PR TITLE
Predict bugfix: save and load preds_mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ clf.fit(
 preds = clf.predict(X_test)
 ```
 
+The targets on `y_train/y_valid` should contain a unique type (i.e. they must all be strings or integers).
+
 ### Default eval_metric
 
 A few classical evaluation metrics are implemented (see bellow section for custom ones):

--- a/census_example.ipynb
+++ b/census_example.ipynb
@@ -289,6 +289,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clf.predict(X_test)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -336,6 +345,15 @@
    "outputs": [],
    "source": [
     "assert(test_auc == loaded_test_auc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loaded_clf.predict(X_test)"
    ]
   },
   {
@@ -461,7 +479,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/forest_example.ipynb
+++ b/forest_example.ipynb
@@ -495,9 +495,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".shap",
+   "display_name": "Python 3",
    "language": "python",
-   "name": ".shap"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -509,7 +509,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/multi_task_example.ipynb
+++ b/multi_task_example.ipynb
@@ -387,6 +387,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loaded_clf.predict(X_test)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -448,7 +457,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.7.5"
   },
   "toc": {
    "base_numbering": 1,

--- a/pytorch_tabnet/multiclass_utils.py
+++ b/pytorch_tabnet/multiclass_utils.py
@@ -16,6 +16,7 @@ from scipy.sparse import lil_matrix
 import scipy.sparse as sp
 
 import numpy as np
+import pandas as pd
 
 
 def _assert_all_finite(X, allow_nan=False):
@@ -344,6 +345,14 @@ def type_of_target(y):
         return "binary"  # [1, 2] or [["a"], ["b"]]
 
 
+def check_unique_type(y):
+    target_types = pd.Series(y).map(type).unique()
+    if len(target_types) != 1:
+        raise TypeError(
+            f"Values on the target must have the same type. Target has types {target_types}"
+        )
+
+
 def infer_output_dim(y_train):
     """
     Infer output_dim from targets
@@ -360,6 +369,7 @@ def infer_output_dim(y_train):
     train_labels : list
         Sorted list of initial classes
     """
+    check_unique_type(y_train)
     train_labels = unique_labels(y_train)
     output_dim = len(train_labels)
 
@@ -368,6 +378,7 @@ def infer_output_dim(y_train):
 
 def check_output_dim(labels, y):
     if y is not None:
+        check_unique_type(y)
         valid_labels = unique_labels(y)
         if not set(valid_labels).issubset(set(labels)):
             raise ValueError(

--- a/pytorch_tabnet/multitask.py
+++ b/pytorch_tabnet/multitask.py
@@ -75,7 +75,7 @@ class TabNetMultiTaskClassifier(TabModel):
             for classes in self.classes_
         ]
         self.preds_mapper = [
-            {index: class_label for index, class_label in enumerate(classes)}
+            {str(index): str(class_label) for index, class_label in enumerate(classes)}
             for classes in self.classes_
         ]
         self.updated_weights = weights
@@ -121,7 +121,7 @@ class TabNetMultiTaskClassifier(TabModel):
         results = [np.hstack(task_res) for task_res in results.values()]
         # map all task individually
         results = [
-            np.vectorize(self.preds_mapper[task_idx].get)(task_res)
+            np.vectorize(self.preds_mapper[task_idx].get)(task_res.astype(str))
             for task_idx, task_res in enumerate(results)
         ]
         return results

--- a/pytorch_tabnet/tab_model.py
+++ b/pytorch_tabnet/tab_model.py
@@ -59,7 +59,7 @@ class TabNetClassifier(TabModel):
             class_label: index for index, class_label in enumerate(self.classes_)
         }
         self.preds_mapper = {
-            index: class_label for index, class_label in enumerate(self.classes_)
+            str(index): class_label for index, class_label in enumerate(self.classes_)
         }
         self.updated_weights = self.weight_updater(weights)
 
@@ -71,7 +71,7 @@ class TabNetClassifier(TabModel):
 
     def predict_func(self, outputs):
         outputs = np.argmax(outputs, axis=1)
-        return np.vectorize(self.preds_mapper.get)(outputs)
+        return np.vectorize(self.preds_mapper.get)(outputs.astype(str))
 
     def predict_proba(self, X):
         """
@@ -132,6 +132,7 @@ class TabNetRegressor(TabModel):
                   "Use reshape(-1, 1) for single regression."
             raise ValueError(msg)
         self.output_dim = y_train.shape[1]
+        self.preds_mapper = None
 
         self.updated_weights = weights
         filter_weights(self.updated_weights)

--- a/pytorch_tabnet/utils.py
+++ b/pytorch_tabnet/utils.py
@@ -3,6 +3,7 @@ from torch.utils.data import DataLoader, WeightedRandomSampler
 import torch
 import numpy as np
 import scipy
+import json
 from sklearn.utils import check_array
 
 
@@ -328,3 +329,11 @@ def define_device(device_name):
         return "cpu"
     else:
         return device_name
+
+
+class ComplexEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.int64):
+            return int(obj)
+        # Let the base class default method raise the TypeError
+        return json.JSONEncoder.default(self, obj)

--- a/regression_example.ipynb
+++ b/regression_example.ipynb
@@ -223,6 +223,56 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Save model and load"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# save tabnet model\n",
+    "saving_path_name = \"./tabnet_model_test_1\"\n",
+    "saved_filepath = clf.save_model(saving_path_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define new model with basic parameters and load state dict weights\n",
+    "loaded_clf = TabNetRegressor()\n",
+    "loaded_clf.load_model(saved_filepath)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loaded_preds = loaded_clf.predict(X_test)\n",
+    "loaded_test_mse = mean_squared_error(loaded_preds, y_test)\n",
+    "\n",
+    "print(f\"FINAL TEST SCORE FOR {dataset_name} : {loaded_test_mse}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert(test_score == loaded_test_mse)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Global explainability : feat importance summing to 1"
    ]
   },
@@ -352,7 +402,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.5"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->
<!-- You can skip this if you're fixing a typo or adding an app to the Showcase.  -->
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Predict does not work from a loaded model. This PR saves the necessary parameters and loads them later. 

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Maybe document that the predicted outputs are always strings. This was done this way because json save/load does not handle `int64` and I did not want to deal with all the possible cases (strings are probably safer).

**Closing issues**
