### PR TITLE
added imports to semi-supervised pre-training ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ A specific customization example notebook is available here : https://github.com
 Added later to TabNet's original paper, semi-supervised pre-training is now available via the class `TabNetPretrainer`:
 
 ```python
+from pytorch_tabnet.pretraining import TabNetPretrainer
+from pytorch_tabnet.tab_model import TabNetClassifier
+
 # TabNetPretrainer
 unsupervised_model = TabNetPretrainer(
     optimizer_fn=torch.optim.Adam,

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ A specific customization example notebook is available here : https://github.com
 Added later to TabNet's original paper, semi-supervised pre-training is now available via the class `TabNetPretrainer`:
 
 ```python
+import torch
 from pytorch_tabnet.pretraining import TabNetPretrainer
 from pytorch_tabnet.tab_model import TabNetClassifier
 


### PR DESCRIPTION
The example for semi-supervised pre-training was missing the import for TabNetPretrainer and TabNetClassifier (this one is shown in a previous example, so it might not be needed).

<!-- In addition to that please answer these questions: -->

**What kind of change does this PR introduce?**

Updated docs

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing

**Closing issues**

N/a
