### PR TITLE
fix: custom loss using inplace operations

### DIFF
--- a/pytorch_tabnet/abstract_model.py
+++ b/pytorch_tabnet/abstract_model.py
@@ -472,7 +472,7 @@ class TabModel(BaseEstimator):
 
         loss = self.compute_loss(output, y)
         # Add the overall sparsity loss
-        loss -= self.lambda_sparse * M_loss
+        loss = loss - self.lambda_sparse * M_loss
 
         # Perform backward pass and optimization
         loss.backward()


### PR DESCRIPTION

**What kind of change does this PR introduce?**

Bugfix for some types of custom losses.
Would be nice if you could test that for the RMSE the custom loss notebook works as intended.

**Does this PR introduce a breaking change?**

No

**What needs to be documented once your changes are merged?**

Nothing