### PR TITLE
feat: enable feature grouping for attention mechanism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,8 @@ commands:
                   name: Install prerequisites and poetry
                   command: |
                       apt update && apt install curl make git libopenblas-base build-essential -y
-                      curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
-                      source $HOME/.poetry/env
+                      curl -sSL https://install.python-poetry.org | python3 -
+                      export PATH="/root/.local/bin:$PATH"
                       poetry config virtualenvs.path $POETRY_CACHE
                       poetry run pip install --upgrade --no-cache-dir pip==20.1;
 
@@ -70,6 +70,7 @@ jobs:
                   name: LintCode
                   shell: bash -leo pipefail
                   command: |
+                      export PATH="/root/.local/bin:$PATH"
                       poetry run flake8
     install:
         executor: python-executor
@@ -87,7 +88,7 @@ jobs:
                   name: Install dependencies
                   shell: bash -leo pipefail
                   command: |
-                      source $HOME/.poetry/env
+                      export PATH="/root/.local/bin:$PATH"
                       poetry config virtualenvs.path $POETRY_CACHE
                       poetry run pip install torch==1.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
                       poetry install
@@ -108,6 +109,7 @@ jobs:
                   name: run unit-tests
                   shell: bash -leo pipefail
                   command: |
+                      export PATH="/root/.local/bin:$PATH"
                       make unit-tests
     test-nb-census:
         executor: python-executor
@@ -122,6 +124,7 @@ jobs:
                   name: run test-nb-census
                   shell: bash -leo pipefail
                   command: |
+                      export PATH="/root/.local/bin:$PATH"
                       make test-nb-census
     test-nb-multi-regression:
         executor: python-executor
@@ -136,6 +139,7 @@ jobs:
                   name: run test-nb-multi-regression
                   shell: bash -leo pipefail
                   command: |
+                      export PATH="/root/.local/bin:$PATH"
                       make test-nb-multi-regression
     test-nb-forest:
         executor: python-executor
@@ -150,6 +154,7 @@ jobs:
                   name: run test-nb-forest
                   shell: bash -leo pipefail
                   command: |
+                      export PATH="/root/.local/bin:$PATH"
                       make test-nb-forest
     test-nb-regression:
         executor: python-executor
@@ -164,6 +169,7 @@ jobs:
                   name: run test-nb-regression
                   shell: bash -leo pipefail
                   command: |
+                      export PATH="/root/.local/bin:$PATH"
                       make test-nb-regression
     test-nb-multi-task:
         executor: python-executor
@@ -178,6 +184,7 @@ jobs:
                   name: run test-nb-multi-task
                   shell: bash -leo pipefail
                   command: |
+                      export PATH="/root/.local/bin:$PATH"
                       make test-nb-multi-task
     test-nb-customization:
         executor: python-executor
@@ -192,6 +199,7 @@ jobs:
                   name: run test-nb-customization
                   shell: bash -leo pipefail
                   command: |
+                      export PATH="/root/.local/bin:$PATH"
                       make test-nb-customization
     test-nb-pretraining:
             executor: python-executor
@@ -206,6 +214,7 @@ jobs:
                     name: run test-nb-pretraining
                     shell: bash -leo pipefail
                     command: |
+                        export PATH="/root/.local/bin:$PATH"
                         make test-nb-pretraining
 workflows:
     version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim-buster@sha256:50de4af76270c893fe36a9ae428951057d6e1a681312d11861970baa150a62e2
 RUN apt update && apt install curl make git libopenblas-base -y
-RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
+RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV SHELL /bin/bash -l
 
 ENV POETRY_CACHE /work/.cache/poetry
@@ -8,8 +8,8 @@ ENV PIP_CACHE_DIR /work/.cache/pip
 ENV JUPYTER_RUNTIME_DIR /work/.cache/jupyter/runtime
 ENV JUPYTER_CONFIG_DIR /work/.cache/jupyter/config
 
-RUN $HOME/.poetry/bin/poetry config virtualenvs.path $POETRY_CACHE
+RUN /root/.local/bin/poetry config virtualenvs.path $POETRY_CACHE
 
-ENV PATH ${PATH}:/root/.poetry/bin:/bin:/usr/local/bin:/usr/bin
+ENV PATH /root/.local/bin:/bin:/usr/local/bin:/usr/bin
 
 CMD ["bash", "-l"]

--- a/Dockerfile_gpu
+++ b/Dockerfile_gpu
@@ -1,5 +1,5 @@
 # GENERATED FROM SCRIPTS
-FROM nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04@sha256:5f16bff6a7272eed75d070b13020c98f89fc5be4ebf6cdc95adffa2b5dce4a31
+FROM nvidia/cuda:11.3.1-runtime-ubuntu20.04
 
 # Avoid tzdata interactive action
 ENV DEBIAN_FRONTEND noninteractive
@@ -199,7 +199,7 @@ RUN set -eux; \
 
 RUN apt update && apt install curl make git libopenblas-base -y
 
-RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
+RUN curl -sSL https://install.python-poetry.org | python3 -
 
 ENV SHELL /bin/bash -l
 
@@ -211,8 +211,8 @@ ENV JUPYTER_RUNTIME_DIR /work/.cache/jupyter/runtime
 
 ENV JUPYTER_CONFIG_DIR /work/.cache/jupyter/config
 
-RUN $HOME/.poetry/bin/poetry config virtualenvs.path $POETRY_CACHE
+RUN /root/.local/bin/poetry config virtualenvs.path $POETRY_CACHE
 
-ENV PATH /root/.poetry/bin:/bin:/usr/local/bin:/usr/bin
+ENV PATH /root/.local/bin:/bin:/usr/local/bin:/usr/bin
 
 CMD ["bash", "-l"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # TabNet : Attentive Interpretable Tabular Learning
 
-This is a pyTorch implementation of Tabnet (Arik, S. O., & Pfister, T. (2019). TabNet: Attentive Interpretable Tabular Learning. arXiv preprint arXiv:1908.07442.) https://arxiv.org/pdf/1908.07442.pdf.
+This is a pyTorch implementation of Tabnet (Arik, S. O., & Pfister, T. (2019). TabNet: Attentive Interpretable Tabular Learning. arXiv preprint arXiv:1908.07442.) https://arxiv.org/pdf/1908.07442.pdf. Please note that some different choices have been made overtime to improve the library which can differ from the orginal paper.
 
 <!--- BADGES: START --->
 [![CircleCI](https://circleci.com/gh/dreamquark-ai/tabnet.svg?style=svg)](https://circleci.com/gh/dreamquark-ai/tabnet)
@@ -67,6 +67,10 @@ If you wan to use it locally within a docker container:
 - `poetry install` to install all the dependencies, including jupyter
 
 - `make notebook` inside the same terminal. You can then follow the link to a jupyter notebook with tabnet installed.
+
+# What is new ?
+
+- from version **> 4.0** attention is now embedding aware. This aims to maintain a good attention mechanism even with large number of embedding. It is also now possible to specify attention groups (using `grouped_features`). Attention is now done at the group level and not feature level. This is especially useful if a dataset has a lot of columns coming from on single source of data (exemple: a text column transformed using TD-IDF).
 
 # Contributing
 
@@ -315,6 +319,12 @@ loaded_clf.load_model(saved_filepath)
 
 - `mask_type: str` (default='sparsemax')
     Either "sparsemax" or "entmax" : this is the masking function to use for selecting features.
+
+- `grouped_features: list of list of ints` (default=None)
+    This allows the model to share it's attention accross feature inside a same group.
+    This can be especially useful when your preprocessing generates correlated or dependant features: like if you use a TF-IDF or a PCA on a text column.
+    Note that feature importance will be exactly the same between features on a same group.
+    Please also note that embeddings generated for a categorical variable are always inside a same group. 
 
 - `n_shared_decoder` : int (default=1)
 

--- a/census_example.ipynb
+++ b/census_example.ipynb
@@ -26,6 +26,26 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ['CUDA_VISIBLE_DEVICES'] = f\"1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "torch.__version__"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -149,6 +169,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Grouped features\n",
+    "\n",
+    "You can now specify groups of feature which will share a common attention.\n",
+    "\n",
+    "This may be very usefull for features comming from a same preprocessing technique like PCA for example."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(features)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grouped_features = [[0, 1, 2], [8, 9, 10]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Network parameters"
    ]
   },
@@ -160,13 +209,14 @@
    "source": [
     "tabnet_params = {\"cat_idxs\":cat_idxs,\n",
     "                 \"cat_dims\":cat_dims,\n",
-    "                 \"cat_emb_dim\":1,\n",
+    "                 \"cat_emb_dim\":2,\n",
     "                 \"optimizer_fn\":torch.optim.Adam,\n",
     "                 \"optimizer_params\":dict(lr=2e-2),\n",
     "                 \"scheduler_params\":{\"step_size\":50, # how to use learning rate scheduler\n",
     "                                 \"gamma\":0.9},\n",
     "                 \"scheduler_fn\":torch.optim.lr_scheduler.StepLR,\n",
-    "                 \"mask_type\":'entmax' # \"sparsemax\"\n",
+    "                 \"mask_type\":'entmax', # \"sparsemax\"\n",
+    "                 \"grouped_features\" : grouped_features\n",
     "                }\n",
     "\n",
     "clf = TabNetClassifier(**tabnet_params\n",
@@ -202,7 +252,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "max_epochs = 100 if not os.getenv(\"CI\", False) else 2"
+    "max_epochs = 50 if not os.getenv(\"CI\", False) else 2"
    ]
   },
   {
@@ -416,9 +466,11 @@
    "source": [
     "fig, axs = plt.subplots(1, 3, figsize=(20,20))\n",
     "\n",
+    "\n",
     "for i in range(3):\n",
     "    axs[i].imshow(masks[i][:50])\n",
-    "    axs[i].set_title(f\"mask {i}\")\n"
+    "    axs[i].set_title(f\"mask {i}\")\n",
+    "    axs[i].set_xticklabels(labels = features, rotation=45)"
    ]
   },
   {
@@ -481,6 +533,13 @@
     "test_auc = roc_auc_score(y_score=preds[:,1], y_true=y_test)\n",
     "print(test_auc)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -499,7 +558,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.13"
   },
   "toc": {
    "base_numbering": 1,

--- a/forest_example.ipynb
+++ b/forest_example.ipynb
@@ -166,6 +166,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# This is a generic pipeline but actually no categorical features are available for this dataset\n",
+    "\n",
     "unused_feat = []\n",
     "\n",
     "features = [ col for col in train.columns if col not in unused_feat+[target]] \n",
@@ -237,7 +239,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "max_epochs = 50 if not os.getenv(\"CI\", False) else 2"
+    "max_epochs = 100 if not os.getenv(\"CI\", False) else 2"
    ]
   },
   {
@@ -513,7 +515,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.13"
   },
   "toc": {
    "base_numbering": 1,

--- a/multi_task_example.ipynb
+++ b/multi_task_example.ipynb
@@ -457,7 +457,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.13"
   },
   "toc": {
    "base_numbering": 1,

--- a/pretraining_example.ipynb
+++ b/pretraining_example.ipynb
@@ -191,6 +191,8 @@
     "    mask_type='entmax', # \"sparsemax\",\n",
     "    n_shared_decoder=1, # nb shared glu for decoding\n",
     "    n_indep_decoder=1, # nb independent glu for decoding\n",
+    "#     grouped_features=[[0, 1]], # you can group features together here\n",
+    "    verbose=5,\n",
     ")"
    ]
   },
@@ -207,7 +209,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "max_epochs = 1000 if not os.getenv(\"CI\", False) else 2"
+    "max_epochs = 100 if not os.getenv(\"CI\", False) else 2 # 1000"
    ]
   },
   {
@@ -225,7 +227,7 @@
     "    batch_size=2048, virtual_batch_size=128,\n",
     "    num_workers=0,\n",
     "    drop_last=False,\n",
-    "    pretraining_ratio=0.8,\n",
+    "    pretraining_ratio=0.5,\n",
     ") "
    ]
   },
@@ -296,11 +298,12 @@
    "outputs": [],
    "source": [
     "clf = TabNetClassifier(optimizer_fn=torch.optim.Adam,\n",
-    "                       optimizer_params=dict(lr=2e-2),\n",
+    "                       optimizer_params=dict(lr=2e-3),\n",
     "                       scheduler_params={\"step_size\":10, # how to use learning rate scheduler\n",
     "                                         \"gamma\":0.9},\n",
     "                       scheduler_fn=torch.optim.lr_scheduler.StepLR,\n",
-    "                       mask_type='sparsemax' # This will be overwritten if using pretrain model\n",
+    "                       mask_type='sparsemax', # This will be overwritten if using pretrain model\n",
+    "                       verbose=5,\n",
     "                      )"
    ]
   },
@@ -322,7 +325,7 @@
     "    num_workers=0,\n",
     "    weights=1,\n",
     "    drop_last=False,\n",
-    "    from_unsupervised=loaded_pretrain\n",
+    "    from_unsupervised=loaded_pretrain,\n",
     "    \n",
     ") "
    ]
@@ -504,7 +507,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.13"
   },
   "toc": {
    "base_numbering": 1,

--- a/pytorch_tabnet/pretraining.py
+++ b/pytorch_tabnet/pretraining.py
@@ -6,7 +6,8 @@ from pytorch_tabnet.utils import (
     create_explain_matrix,
     filter_weights,
     PredictDataset,
-    check_input
+    check_input,
+    create_group_matrix,
 )
 from torch.nn.utils import clip_grad_norm_
 from pytorch_tabnet.pretraining_utils import (
@@ -172,6 +173,9 @@ class TabNetPretrainer(TabModel):
         if not hasattr(self, 'pretraining_ratio'):
             self.pretraining_ratio = 0.5
         torch.manual_seed(self.seed)
+
+        self.group_matrix = create_group_matrix(self.grouped_features, self.input_dim)
+
         self.network = tab_network.TabNetPretraining(
             self.input_dim,
             pretraining_ratio=self.pretraining_ratio,
@@ -188,6 +192,7 @@ class TabNetPretrainer(TabModel):
             virtual_batch_size=self.virtual_batch_size,
             momentum=self.momentum,
             mask_type=self.mask_type,
+            group_attention_matrix=self.group_matrix.to(self.device),
         ).to(self.device)
 
         self.reducing_matrix = create_explain_matrix(

--- a/pytorch_tabnet/utils.py
+++ b/pytorch_tabnet/utils.py
@@ -216,6 +216,93 @@ def create_explain_matrix(input_dim, cat_emb_dim, cat_idxs, post_embed_dim):
     return scipy.sparse.csc_matrix(reducing_matrix)
 
 
+def create_group_matrix(list_groups, input_dim):
+    """
+    Create the group matrix corresponding to the given list_groups
+
+    Parameters
+    ----------
+    - list_groups : list of list of int
+        Each element is a list representing features in the same group.
+        One feature should appear in maximum one group.
+        Feature that don't get assigned a group will be in their own group of one feature.
+    - input_dim : number of feature in the initial dataset
+
+    Returns
+    -------
+    - group_matrix : torch matrix
+        A matrix of size (n_groups, input_dim)
+        where m_ij represents the importance of feature j in group i
+        The rows must some to 1 as each group is equally important a priori.
+
+    """
+    check_list_groups(list_groups, input_dim)
+
+    if len(list_groups) == 0:
+        group_matrix = torch.eye(input_dim)
+        return group_matrix
+    else:
+        n_groups = input_dim - int(np.sum([len(gp) - 1 for gp in list_groups]))
+        group_matrix = torch.zeros((n_groups, input_dim))
+
+        remaining_features = [feat_idx for feat_idx in range(input_dim)]
+
+        current_group_idx = 0
+        for group in list_groups:
+            group_size = len(group)
+            for elem_idx in group:
+                # add importrance of element in group matrix and corresponding group
+                group_matrix[current_group_idx, elem_idx] = 1 / group_size
+                # remove features from list of features
+                remaining_features.remove(elem_idx)
+            # move to next group
+            current_group_idx += 1
+        # features not mentionned in list_groups get assigned their own group of singleton
+        for remaining_feat_idx in remaining_features:
+            group_matrix[current_group_idx, remaining_feat_idx] = 1
+            current_group_idx += 1
+        return group_matrix
+
+
+def check_list_groups(list_groups, input_dim):
+    """
+    Check that list groups:
+        - is a list of list
+        - does not contain twice the same feature in different groups
+        - does not contain unknown features (>= input_dim)
+        - does not contain empty groups
+    Parameters
+    ----------
+    - list_groups : list of list of int
+        Each element is a list representing features in the same group.
+        One feature should appear in maximum one group.
+        Feature that don't get assign a group will be in their own group of one feature.
+    - input_dim : number of feature in the initial dataset
+    """
+    assert isinstance(list_groups, list), "list_groups must be a list of list."
+
+    if len(list_groups) == 0:
+        return
+    else:
+        for group_pos, group in enumerate(list_groups):
+            msg = f"Groups must be given as a list of list, but found {group} in position {group_pos}."  # noqa
+            assert isinstance(group, list), msg
+            assert len(group) > 0, "Empty groups are forbidding please remove empty groups []"
+
+    n_elements_in_groups = np.sum([len(group) for group in list_groups])
+    flat_list = []
+    for group in list_groups:
+        flat_list.extend(group)
+    unique_elements = np.unique(flat_list)
+    n_unique_elements_in_groups = len(unique_elements)
+    msg = f"One feature can only appear in one group, please check your grouped_features."
+    assert n_unique_elements_in_groups == n_elements_in_groups, msg
+
+    highest_feat = np.max(unique_elements)
+    assert highest_feat < input_dim, f"Number of features is {input_dim} but one group contains {highest_feat}."  # noqa
+    return
+
+
 def filter_weights(weights):
     """
     This function makes sure that weights are in correct format for
@@ -361,3 +448,37 @@ def check_warm_start(warm_start, from_unsupervised):
         warn_msg = "warm_start will be ignore, training will start from unsupervised weights"
         warnings.warn(warn_msg)
     return
+
+
+def check_embedding_parameters(cat_dims, cat_idxs, cat_emb_dim):
+    """
+    Check parameters related to embeddings and rearrange them in a unique manner.
+    """
+    if (cat_dims == []) ^ (cat_idxs == []):
+        if cat_dims == []:
+            msg = "If cat_idxs is non-empty, cat_dims must be defined as a list of same length."
+        else:
+            msg = "If cat_dims is non-empty, cat_idxs must be defined as a list of same length."
+        raise ValueError(msg)
+    elif len(cat_dims) != len(cat_idxs):
+        msg = "The lists cat_dims and cat_idxs must have the same length."
+        raise ValueError(msg)
+
+    if isinstance(cat_emb_dim, int):
+        cat_emb_dims = [cat_emb_dim] * len(cat_idxs)
+    else:
+        cat_emb_dims = cat_emb_dim
+
+    # check that all embeddings are provided
+    if len(cat_emb_dims) != len(cat_dims):
+        msg = f"""cat_emb_dim and cat_dims must be lists of same length, got {len(cat_emb_dims)}
+                    and {len(cat_dims)}"""
+        raise ValueError(msg)
+
+    # Rearrange to get reproducible seeds with different ordering
+    if len(cat_idxs) > 0:
+        sorted_idxs = np.argsort(cat_idxs)
+        cat_dims = [cat_dims[i] for i in sorted_idxs]
+        cat_emb_dims = [cat_emb_dims[i] for i in sorted_idxs]
+
+    return cat_dims, cat_idxs, cat_emb_dims

--- a/regression_example.ipynb
+++ b/regression_example.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -42,17 +42,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "File already exists.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "out.parent.mkdir(parents=True, exist_ok=True)\n",
     "if out.exists():\n",
@@ -71,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,26 +88,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " State-gov 9\n",
-      " Bachelors 16\n",
-      " Never-married 7\n",
-      " Adm-clerical 15\n",
-      " Not-in-family 6\n",
-      " White 5\n",
-      " Male 2\n",
-      " United-States 42\n",
-      " <=50K 2\n",
-      "Set 3\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "categorical_columns = []\n",
     "categorical_dims =  {}\n",
@@ -140,7 +115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,18 +140,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/work/pytorch_tabnet/abstract_model.py:75: UserWarning: Device used : cuda\n",
-      "  warnings.warn(f\"Device used : {self.device}\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "clf = TabNetRegressor(cat_dims=cat_dims, cat_emb_dim=cat_emb_dim, cat_idxs=cat_idxs)"
    ]
@@ -190,7 +156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,139 +191,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "epoch 0  | loss: 0.16632 | train_rmsle: 0.08172 | train_mae: 0.32434 | train_rmse: 0.42037 | train_mse: 0.17671 | valid_rmsle: 0.08229 | valid_mae: 0.32509 | valid_rmse: 0.41638 | valid_mse: 0.17337 |  0:00:01s\n",
-      "epoch 1  | loss: 0.13043 | train_rmsle: 0.08851 | train_mae: 0.34694 | train_rmse: 0.43319 | train_mse: 0.18765 | valid_rmsle: 0.08877 | valid_mae: 0.34742 | valid_rmse: 0.43215 | valid_mse: 0.18676 |  0:00:02s\n",
-      "epoch 2  | loss: 0.12421 | train_rmsle: 0.07367 | train_mae: 0.31208 | train_rmse: 0.38054 | train_mse: 0.14481 | valid_rmsle: 0.07219 | valid_mae: 0.30876 | valid_rmse: 0.37698 | valid_mse: 0.14211 |  0:00:04s\n",
-      "epoch 3  | loss: 0.11857 | train_rmsle: 0.08045 | train_mae: 0.30774 | train_rmse: 0.38188 | train_mse: 0.14583 | valid_rmsle: 0.08033 | valid_mae: 0.30664 | valid_rmse: 0.38204 | valid_mse: 0.14595 |  0:00:05s\n",
-      "epoch 4  | loss: 0.11478 | train_rmsle: 0.0657  | train_mae: 0.2798  | train_rmse: 0.35083 | train_mse: 0.12308 | valid_rmsle: 0.06471 | valid_mae: 0.2762  | valid_rmse: 0.34809 | valid_mse: 0.12116 |  0:00:07s\n",
-      "epoch 5  | loss: 0.11121 | train_rmsle: 0.05961 | train_mae: 0.25979 | train_rmse: 0.34053 | train_mse: 0.11596 | valid_rmsle: 0.05839 | valid_mae: 0.2566  | valid_rmse: 0.33742 | valid_mse: 0.11385 |  0:00:08s\n",
-      "epoch 6  | loss: 0.11029 | train_rmsle: 0.06378 | train_mae: 0.25423 | train_rmse: 0.35531 | train_mse: 0.12624 | valid_rmsle: 0.06213 | valid_mae: 0.25054 | valid_rmse: 0.35461 | valid_mse: 0.12575 |  0:00:09s\n",
-      "epoch 7  | loss: 0.11003 | train_rmsle: 0.057   | train_mae: 0.25219 | train_rmse: 0.34344 | train_mse: 0.11795 | valid_rmsle: 0.05512 | valid_mae: 0.2475  | valid_rmse: 0.33776 | valid_mse: 0.11408 |  0:00:11s\n",
-      "epoch 8  | loss: 0.10988 | train_rmsle: 0.05512 | train_mae: 0.24226 | train_rmse: 0.33481 | train_mse: 0.1121  | valid_rmsle: 0.05343 | valid_mae: 0.23781 | valid_rmse: 0.32937 | valid_mse: 0.10848 |  0:00:12s\n",
-      "epoch 9  | loss: 0.10829 | train_rmsle: 0.05693 | train_mae: 0.24596 | train_rmse: 0.33503 | train_mse: 0.11225 | valid_rmsle: 0.05497 | valid_mae: 0.24018 | valid_rmse: 0.32932 | valid_mse: 0.10845 |  0:00:13s\n",
-      "epoch 10 | loss: 0.10833 | train_rmsle: 0.05375 | train_mae: 0.23563 | train_rmse: 0.33305 | train_mse: 0.11092 | valid_rmsle: 0.05185 | valid_mae: 0.23062 | valid_rmse: 0.32643 | valid_mse: 0.10656 |  0:00:15s\n",
-      "epoch 11 | loss: 0.10764 | train_rmsle: 0.0526  | train_mae: 0.22899 | train_rmse: 0.33287 | train_mse: 0.1108  | valid_rmsle: 0.05076 | valid_mae: 0.22411 | valid_rmse: 0.3265  | valid_mse: 0.1066  |  0:00:16s\n",
-      "epoch 12 | loss: 0.10698 | train_rmsle: 0.05624 | train_mae: 0.23993 | train_rmse: 0.33312 | train_mse: 0.11097 | valid_rmsle: 0.05461 | valid_mae: 0.2353  | valid_rmse: 0.32751 | valid_mse: 0.10726 |  0:00:18s\n",
-      "epoch 13 | loss: 0.10679 | train_rmsle: 0.05276 | train_mae: 0.22877 | train_rmse: 0.33555 | train_mse: 0.1126  | valid_rmsle: 0.05128 | valid_mae: 0.22473 | valid_rmse: 0.33015 | valid_mse: 0.109   |  0:00:19s\n",
-      "epoch 14 | loss: 0.10577 | train_rmsle: 0.05284 | train_mae: 0.22906 | train_rmse: 0.32791 | train_mse: 0.10752 | valid_rmsle: 0.05154 | valid_mae: 0.22525 | valid_rmse: 0.32335 | valid_mse: 0.10455 |  0:00:20s\n",
-      "epoch 15 | loss: 0.10497 | train_rmsle: 0.05111 | train_mae: 0.22535 | train_rmse: 0.32761 | train_mse: 0.10733 | valid_rmsle: 0.05009 | valid_mae: 0.22221 | valid_rmse: 0.32379 | valid_mse: 0.10484 |  0:00:22s\n",
-      "epoch 16 | loss: 0.10512 | train_rmsle: 0.05156 | train_mae: 0.22343 | train_rmse: 0.32994 | train_mse: 0.10886 | valid_rmsle: 0.05017 | valid_mae: 0.21935 | valid_rmse: 0.32502 | valid_mse: 0.10564 |  0:00:23s\n",
-      "epoch 17 | loss: 0.10614 | train_rmsle: 0.05414 | train_mae: 0.22927 | train_rmse: 0.32792 | train_mse: 0.10753 | valid_rmsle: 0.05246 | valid_mae: 0.22524 | valid_rmse: 0.32246 | valid_mse: 0.10398 |  0:00:25s\n",
-      "epoch 18 | loss: 0.1028  | train_rmsle: 0.05195 | train_mae: 0.22859 | train_rmse: 0.32487 | train_mse: 0.10554 | valid_rmsle: 0.05053 | valid_mae: 0.22437 | valid_rmse: 0.32036 | valid_mse: 0.10263 |  0:00:26s\n",
-      "epoch 19 | loss: 0.10342 | train_rmsle: 0.05142 | train_mae: 0.22324 | train_rmse: 0.32451 | train_mse: 0.10531 | valid_rmsle: 0.04992 | valid_mae: 0.21936 | valid_rmse: 0.31937 | valid_mse: 0.10199 |  0:00:27s\n",
-      "epoch 20 | loss: 0.10317 | train_rmsle: 0.05125 | train_mae: 0.22449 | train_rmse: 0.32393 | train_mse: 0.10493 | valid_rmsle: 0.04942 | valid_mae: 0.22011 | valid_rmse: 0.31785 | valid_mse: 0.10103 |  0:00:29s\n",
-      "epoch 21 | loss: 0.10194 | train_rmsle: 0.0503  | train_mae: 0.21491 | train_rmse: 0.32128 | train_mse: 0.10322 | valid_rmsle: 0.0485  | valid_mae: 0.21037 | valid_rmse: 0.31517 | valid_mse: 0.09933 |  0:00:30s\n",
-      "epoch 22 | loss: 0.10324 | train_rmsle: 0.05067 | train_mae: 0.22173 | train_rmse: 0.3247  | train_mse: 0.10543 | valid_rmsle: 0.04861 | valid_mae: 0.21679 | valid_rmse: 0.31732 | valid_mse: 0.10069 |  0:00:31s\n",
-      "epoch 23 | loss: 0.10248 | train_rmsle: 0.05005 | train_mae: 0.21331 | train_rmse: 0.32139 | train_mse: 0.10329 | valid_rmsle: 0.04804 | valid_mae: 0.20833 | valid_rmse: 0.31477 | valid_mse: 0.09908 |  0:00:33s\n",
-      "epoch 24 | loss: 0.10151 | train_rmsle: 0.04969 | train_mae: 0.215   | train_rmse: 0.32014 | train_mse: 0.10249 | valid_rmsle: 0.04756 | valid_mae: 0.20974 | valid_rmse: 0.31347 | valid_mse: 0.09826 |  0:00:34s\n",
-      "epoch 25 | loss: 0.10211 | train_rmsle: 0.04935 | train_mae: 0.21158 | train_rmse: 0.3224  | train_mse: 0.10394 | valid_rmsle: 0.04687 | valid_mae: 0.20514 | valid_rmse: 0.31442 | valid_mse: 0.09886 |  0:00:36s\n",
-      "epoch 26 | loss: 0.10208 | train_rmsle: 0.04962 | train_mae: 0.21607 | train_rmse: 0.31855 | train_mse: 0.10148 | valid_rmsle: 0.04761 | valid_mae: 0.21083 | valid_rmse: 0.31159 | valid_mse: 0.09709 |  0:00:37s\n",
-      "epoch 27 | loss: 0.10094 | train_rmsle: 0.05275 | train_mae: 0.22095 | train_rmse: 0.32081 | train_mse: 0.10292 | valid_rmsle: 0.05063 | valid_mae: 0.2158  | valid_rmse: 0.3131  | valid_mse: 0.09803 |  0:00:39s\n",
-      "epoch 28 | loss: 0.10124 | train_rmsle: 0.04891 | train_mae: 0.2123  | train_rmse: 0.32237 | train_mse: 0.10392 | valid_rmsle: 0.04737 | valid_mae: 0.20892 | valid_rmse: 0.31726 | valid_mse: 0.10065 |  0:00:40s\n",
-      "epoch 29 | loss: 0.10122 | train_rmsle: 0.04956 | train_mae: 0.2099  | train_rmse: 0.31865 | train_mse: 0.10154 | valid_rmsle: 0.04759 | valid_mae: 0.20479 | valid_rmse: 0.31198 | valid_mse: 0.09733 |  0:00:41s\n",
-      "epoch 30 | loss: 0.10027 | train_rmsle: 0.0496  | train_mae: 0.21145 | train_rmse: 0.31576 | train_mse: 0.0997  | valid_rmsle: 0.04841 | valid_mae: 0.20842 | valid_rmse: 0.31175 | valid_mse: 0.09719 |  0:00:43s\n",
-      "epoch 31 | loss: 0.10034 | train_rmsle: 0.05005 | train_mae: 0.21385 | train_rmse: 0.3167  | train_mse: 0.1003  | valid_rmsle: 0.049   | valid_mae: 0.21084 | valid_rmse: 0.31334 | valid_mse: 0.09818 |  0:00:44s\n",
-      "epoch 32 | loss: 0.09935 | train_rmsle: 0.04969 | train_mae: 0.21522 | train_rmse: 0.31826 | train_mse: 0.10129 | valid_rmsle: 0.04807 | valid_mae: 0.2116  | valid_rmse: 0.31319 | valid_mse: 0.09809 |  0:00:46s\n",
-      "epoch 33 | loss: 0.09984 | train_rmsle: 0.04837 | train_mae: 0.21348 | train_rmse: 0.31861 | train_mse: 0.10152 | valid_rmsle: 0.04715 | valid_mae: 0.21017 | valid_rmse: 0.31453 | valid_mse: 0.09893 |  0:00:47s\n",
-      "epoch 34 | loss: 0.09977 | train_rmsle: 0.04906 | train_mae: 0.2057  | train_rmse: 0.31576 | train_mse: 0.09971 | valid_rmsle: 0.04742 | valid_mae: 0.20152 | valid_rmse: 0.31029 | valid_mse: 0.09628 |  0:00:48s\n",
-      "epoch 35 | loss: 0.09988 | train_rmsle: 0.04863 | train_mae: 0.20762 | train_rmse: 0.31561 | train_mse: 0.09961 | valid_rmsle: 0.04672 | valid_mae: 0.20284 | valid_rmse: 0.30913 | valid_mse: 0.09556 |  0:00:50s\n",
-      "epoch 36 | loss: 0.10015 | train_rmsle: 0.04951 | train_mae: 0.21187 | train_rmse: 0.31592 | train_mse: 0.09981 | valid_rmsle: 0.04835 | valid_mae: 0.20902 | valid_rmse: 0.31217 | valid_mse: 0.09745 |  0:00:51s\n",
-      "epoch 37 | loss: 0.10147 | train_rmsle: 0.05169 | train_mae: 0.2214  | train_rmse: 0.32128 | train_mse: 0.10322 | valid_rmsle: 0.04984 | valid_mae: 0.21678 | valid_rmse: 0.31476 | valid_mse: 0.09908 |  0:00:53s\n",
-      "epoch 38 | loss: 0.10198 | train_rmsle: 0.04936 | train_mae: 0.21867 | train_rmse: 0.32333 | train_mse: 0.10454 | valid_rmsle: 0.04824 | valid_mae: 0.21547 | valid_rmse: 0.31959 | valid_mse: 0.10214 |  0:00:54s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "epoch 39 | loss: 0.10109 | train_rmsle: 0.05026 | train_mae: 0.21729 | train_rmse: 0.31905 | train_mse: 0.1018  | valid_rmsle: 0.04844 | valid_mae: 0.21238 | valid_rmse: 0.31259 | valid_mse: 0.09771 |  0:00:55s\n",
-      "epoch 40 | loss: 0.1015  | train_rmsle: 0.05009 | train_mae: 0.21863 | train_rmse: 0.31728 | train_mse: 0.10067 | valid_rmsle: 0.04864 | valid_mae: 0.21431 | valid_rmse: 0.31218 | valid_mse: 0.09746 |  0:00:57s\n",
-      "epoch 41 | loss: 0.10149 | train_rmsle: 0.04867 | train_mae: 0.21139 | train_rmse: 0.32118 | train_mse: 0.10316 | valid_rmsle: 0.04726 | valid_mae: 0.20743 | valid_rmse: 0.31627 | valid_mse: 0.10002 |  0:00:58s\n",
-      "epoch 42 | loss: 0.10082 | train_rmsle: 0.0507  | train_mae: 0.21215 | train_rmse: 0.31643 | train_mse: 0.10013 | valid_rmsle: 0.04898 | valid_mae: 0.20688 | valid_rmse: 0.31061 | valid_mse: 0.09648 |  0:01:00s\n",
-      "epoch 43 | loss: 0.1012  | train_rmsle: 0.05138 | train_mae: 0.21497 | train_rmse: 0.31801 | train_mse: 0.10113 | valid_rmsle: 0.04964 | valid_mae: 0.21004 | valid_rmse: 0.31243 | valid_mse: 0.09761 |  0:01:01s\n",
-      "epoch 44 | loss: 0.09969 | train_rmsle: 0.05366 | train_mae: 0.21694 | train_rmse: 0.32127 | train_mse: 0.10321 | valid_rmsle: 0.05198 | valid_mae: 0.21147 | valid_rmse: 0.31592 | valid_mse: 0.09981 |  0:01:02s\n",
-      "epoch 45 | loss: 0.09983 | train_rmsle: 0.04806 | train_mae: 0.20948 | train_rmse: 0.3201  | train_mse: 0.10246 | valid_rmsle: 0.04689 | valid_mae: 0.20623 | valid_rmse: 0.31651 | valid_mse: 0.10018 |  0:01:04s\n",
-      "epoch 46 | loss: 0.09854 | train_rmsle: 0.04937 | train_mae: 0.20906 | train_rmse: 0.31537 | train_mse: 0.09946 | valid_rmsle: 0.04784 | valid_mae: 0.20508 | valid_rmse: 0.31005 | valid_mse: 0.09613 |  0:01:05s\n",
-      "epoch 47 | loss: 0.09865 | train_rmsle: 0.04765 | train_mae: 0.20356 | train_rmse: 0.31644 | train_mse: 0.10013 | valid_rmsle: 0.0461  | valid_mae: 0.19918 | valid_rmse: 0.31127 | valid_mse: 0.09689 |  0:01:07s\n",
-      "epoch 48 | loss: 0.09813 | train_rmsle: 0.04759 | train_mae: 0.2065  | train_rmse: 0.31669 | train_mse: 0.10029 | valid_rmsle: 0.04641 | valid_mae: 0.20337 | valid_rmse: 0.31259 | valid_mse: 0.09771 |  0:01:08s\n",
-      "epoch 49 | loss: 0.09894 | train_rmsle: 0.04811 | train_mae: 0.21058 | train_rmse: 0.31469 | train_mse: 0.09903 | valid_rmsle: 0.04708 | valid_mae: 0.20755 | valid_rmse: 0.31112 | valid_mse: 0.0968  |  0:01:09s\n",
-      "epoch 50 | loss: 0.09902 | train_rmsle: 0.04838 | train_mae: 0.20795 | train_rmse: 0.31515 | train_mse: 0.09932 | valid_rmsle: 0.04738 | valid_mae: 0.20433 | valid_rmse: 0.31136 | valid_mse: 0.09695 |  0:01:11s\n",
-      "epoch 51 | loss: 0.09911 | train_rmsle: 0.0484  | train_mae: 0.20765 | train_rmse: 0.31505 | train_mse: 0.09925 | valid_rmsle: 0.04698 | valid_mae: 0.20378 | valid_rmse: 0.31041 | valid_mse: 0.09635 |  0:01:12s\n",
-      "epoch 52 | loss: 0.09917 | train_rmsle: 0.04775 | train_mae: 0.20601 | train_rmse: 0.3163  | train_mse: 0.10005 | valid_rmsle: 0.04622 | valid_mae: 0.20242 | valid_rmse: 0.31109 | valid_mse: 0.09678 |  0:01:14s\n",
-      "epoch 53 | loss: 0.0982  | train_rmsle: 0.04794 | train_mae: 0.20522 | train_rmse: 0.31544 | train_mse: 0.0995  | valid_rmsle: 0.04642 | valid_mae: 0.20135 | valid_rmse: 0.31003 | valid_mse: 0.09612 |  0:01:15s\n",
-      "epoch 54 | loss: 0.09837 | train_rmsle: 0.04802 | train_mae: 0.20703 | train_rmse: 0.31501 | train_mse: 0.09923 | valid_rmsle: 0.04645 | valid_mae: 0.20307 | valid_rmse: 0.30927 | valid_mse: 0.09565 |  0:01:16s\n",
-      "epoch 55 | loss: 0.09796 | train_rmsle: 0.04762 | train_mae: 0.2029  | train_rmse: 0.31699 | train_mse: 0.10048 | valid_rmsle: 0.04655 | valid_mae: 0.20033 | valid_rmse: 0.31329 | valid_mse: 0.09815 |  0:01:18s\n",
-      "epoch 56 | loss: 0.09951 | train_rmsle: 0.04796 | train_mae: 0.20457 | train_rmse: 0.31803 | train_mse: 0.10114 | valid_rmsle: 0.0467  | valid_mae: 0.20155 | valid_rmse: 0.31322 | valid_mse: 0.09811 |  0:01:19s\n",
-      "epoch 57 | loss: 0.09864 | train_rmsle: 0.04795 | train_mae: 0.20608 | train_rmse: 0.31984 | train_mse: 0.1023  | valid_rmsle: 0.04688 | valid_mae: 0.20307 | valid_rmse: 0.31594 | valid_mse: 0.09982 |  0:01:21s\n",
-      "epoch 58 | loss: 0.09906 | train_rmsle: 0.04846 | train_mae: 0.20418 | train_rmse: 0.31676 | train_mse: 0.10034 | valid_rmsle: 0.04721 | valid_mae: 0.20046 | valid_rmse: 0.31195 | valid_mse: 0.09732 |  0:01:22s\n",
-      "epoch 59 | loss: 0.09942 | train_rmsle: 0.04874 | train_mae: 0.20833 | train_rmse: 0.31395 | train_mse: 0.09856 | valid_rmsle: 0.04808 | valid_mae: 0.20561 | valid_rmse: 0.31126 | valid_mse: 0.09689 |  0:01:23s\n",
-      "epoch 60 | loss: 0.09816 | train_rmsle: 0.04848 | train_mae: 0.20814 | train_rmse: 0.3157  | train_mse: 0.09967 | valid_rmsle: 0.04738 | valid_mae: 0.20452 | valid_rmse: 0.31145 | valid_mse: 0.097   |  0:01:25s\n",
-      "epoch 61 | loss: 0.09783 | train_rmsle: 0.04989 | train_mae: 0.20517 | train_rmse: 0.31546 | train_mse: 0.09951 | valid_rmsle: 0.04939 | valid_mae: 0.20392 | valid_rmse: 0.31329 | valid_mse: 0.09815 |  0:01:26s\n",
-      "epoch 62 | loss: 0.09757 | train_rmsle: 0.0489  | train_mae: 0.20754 | train_rmse: 0.31342 | train_mse: 0.09823 | valid_rmsle: 0.04812 | valid_mae: 0.20535 | valid_rmse: 0.31025 | valid_mse: 0.09626 |  0:01:28s\n",
-      "epoch 63 | loss: 0.09733 | train_rmsle: 0.05012 | train_mae: 0.20823 | train_rmse: 0.31422 | train_mse: 0.09873 | valid_rmsle: 0.04929 | valid_mae: 0.20605 | valid_rmse: 0.31077 | valid_mse: 0.09658 |  0:01:29s\n",
-      "epoch 64 | loss: 0.09746 | train_rmsle: 0.04716 | train_mae: 0.20427 | train_rmse: 0.31561 | train_mse: 0.09961 | valid_rmsle: 0.04616 | valid_mae: 0.20203 | valid_rmse: 0.31183 | valid_mse: 0.09724 |  0:01:30s\n",
-      "epoch 65 | loss: 0.09895 | train_rmsle: 0.04738 | train_mae: 0.2032  | train_rmse: 0.31327 | train_mse: 0.09814 | valid_rmsle: 0.0465  | valid_mae: 0.20116 | valid_rmse: 0.31021 | valid_mse: 0.09623 |  0:01:32s\n",
-      "epoch 66 | loss: 0.09839 | train_rmsle: 0.04817 | train_mae: 0.21045 | train_rmse: 0.31406 | train_mse: 0.09864 | valid_rmsle: 0.04732 | valid_mae: 0.20821 | valid_rmse: 0.31109 | valid_mse: 0.09677 |  0:01:33s\n",
-      "epoch 67 | loss: 0.09867 | train_rmsle: 0.04858 | train_mae: 0.20448 | train_rmse: 0.31458 | train_mse: 0.09896 | valid_rmsle: 0.04756 | valid_mae: 0.20188 | valid_rmse: 0.31064 | valid_mse: 0.0965  |  0:01:34s\n",
-      "epoch 68 | loss: 0.0975  | train_rmsle: 0.04824 | train_mae: 0.20539 | train_rmse: 0.31288 | train_mse: 0.09789 | valid_rmsle: 0.04716 | valid_mae: 0.203   | valid_rmse: 0.30895 | valid_mse: 0.09545 |  0:01:36s\n",
-      "epoch 69 | loss: 0.09763 | train_rmsle: 0.04792 | train_mae: 0.20796 | train_rmse: 0.31485 | train_mse: 0.09913 | valid_rmsle: 0.04667 | valid_mae: 0.20488 | valid_rmse: 0.31019 | valid_mse: 0.09622 |  0:01:37s\n",
-      "epoch 70 | loss: 0.09723 | train_rmsle: 0.04897 | train_mae: 0.2058  | train_rmse: 0.31261 | train_mse: 0.09773 | valid_rmsle: 0.04791 | valid_mae: 0.2035  | valid_rmse: 0.30854 | valid_mse: 0.0952  |  0:01:39s\n",
-      "epoch 71 | loss: 0.09762 | train_rmsle: 0.04741 | train_mae: 0.20414 | train_rmse: 0.31256 | train_mse: 0.0977  | valid_rmsle: 0.04639 | valid_mae: 0.20201 | valid_rmse: 0.30874 | valid_mse: 0.09532 |  0:01:40s\n",
-      "epoch 72 | loss: 0.0971  | train_rmsle: 0.04862 | train_mae: 0.20357 | train_rmse: 0.31456 | train_mse: 0.09895 | valid_rmsle: 0.04736 | valid_mae: 0.20057 | valid_rmse: 0.30995 | valid_mse: 0.09607 |  0:01:41s\n",
-      "epoch 73 | loss: 0.09689 | train_rmsle: 0.04786 | train_mae: 0.21148 | train_rmse: 0.31723 | train_mse: 0.10063 | valid_rmsle: 0.04678 | valid_mae: 0.20891 | valid_rmse: 0.31349 | valid_mse: 0.09828 |  0:01:43s\n",
-      "epoch 74 | loss: 0.09743 | train_rmsle: 0.04749 | train_mae: 0.20384 | train_rmse: 0.31325 | train_mse: 0.09812 | valid_rmsle: 0.04617 | valid_mae: 0.20132 | valid_rmse: 0.30846 | valid_mse: 0.09515 |  0:01:44s\n",
-      "epoch 75 | loss: 0.0972  | train_rmsle: 0.04803 | train_mae: 0.20561 | train_rmse: 0.31244 | train_mse: 0.09762 | valid_rmsle: 0.04672 | valid_mae: 0.20277 | valid_rmse: 0.30754 | valid_mse: 0.09458 |  0:01:45s\n",
-      "epoch 76 | loss: 0.09595 | train_rmsle: 0.0478  | train_mae: 0.20355 | train_rmse: 0.31466 | train_mse: 0.09901 | valid_rmsle: 0.04658 | valid_mae: 0.20084 | valid_rmse: 0.31016 | valid_mse: 0.0962  |  0:01:47s\n",
-      "epoch 77 | loss: 0.09632 | train_rmsle: 0.0472  | train_mae: 0.20232 | train_rmse: 0.31319 | train_mse: 0.09809 | valid_rmsle: 0.04605 | valid_mae: 0.20031 | valid_rmse: 0.30921 | valid_mse: 0.09561 |  0:01:48s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "epoch 78 | loss: 0.09692 | train_rmsle: 0.04901 | train_mae: 0.20755 | train_rmse: 0.31433 | train_mse: 0.0988  | valid_rmsle: 0.04771 | valid_mae: 0.20417 | valid_rmse: 0.30959 | valid_mse: 0.09585 |  0:01:50s\n",
-      "epoch 79 | loss: 0.09665 | train_rmsle: 0.04741 | train_mae: 0.2011  | train_rmse: 0.31131 | train_mse: 0.09691 | valid_rmsle: 0.04623 | valid_mae: 0.19879 | valid_rmse: 0.30713 | valid_mse: 0.09433 |  0:01:51s\n",
-      "epoch 80 | loss: 0.09707 | train_rmsle: 0.04718 | train_mae: 0.20445 | train_rmse: 0.31355 | train_mse: 0.09831 | valid_rmsle: 0.04589 | valid_mae: 0.20147 | valid_rmse: 0.30907 | valid_mse: 0.09552 |  0:01:52s\n",
-      "epoch 81 | loss: 0.09612 | train_rmsle: 0.04716 | train_mae: 0.20586 | train_rmse: 0.31175 | train_mse: 0.09719 | valid_rmsle: 0.04576 | valid_mae: 0.20278 | valid_rmse: 0.30691 | valid_mse: 0.09419 |  0:01:54s\n",
-      "epoch 82 | loss: 0.09604 | train_rmsle: 0.04763 | train_mae: 0.20646 | train_rmse: 0.31163 | train_mse: 0.09711 | valid_rmsle: 0.04651 | valid_mae: 0.20362 | valid_rmse: 0.30755 | valid_mse: 0.09459 |  0:01:55s\n",
-      "epoch 83 | loss: 0.09563 | train_rmsle: 0.04713 | train_mae: 0.20618 | train_rmse: 0.31666 | train_mse: 0.10027 | valid_rmsle: 0.04591 | valid_mae: 0.20295 | valid_rmse: 0.3122  | valid_mse: 0.09747 |  0:01:56s\n",
-      "epoch 84 | loss: 0.09528 | train_rmsle: 0.0471  | train_mae: 0.20568 | train_rmse: 0.31303 | train_mse: 0.09799 | valid_rmsle: 0.04643 | valid_mae: 0.20403 | valid_rmse: 0.31028 | valid_mse: 0.09627 |  0:01:58s\n",
-      "epoch 85 | loss: 0.09574 | train_rmsle: 0.04854 | train_mae: 0.2081  | train_rmse: 0.31425 | train_mse: 0.09875 | valid_rmsle: 0.04779 | valid_mae: 0.20611 | valid_rmse: 0.31135 | valid_mse: 0.09694 |  0:01:59s\n",
-      "epoch 86 | loss: 0.09567 | train_rmsle: 0.04867 | train_mae: 0.20816 | train_rmse: 0.31457 | train_mse: 0.09895 | valid_rmsle: 0.0474  | valid_mae: 0.20504 | valid_rmse: 0.30997 | valid_mse: 0.09608 |  0:02:01s\n",
-      "epoch 87 | loss: 0.09636 | train_rmsle: 0.04716 | train_mae: 0.20594 | train_rmse: 0.31315 | train_mse: 0.09806 | valid_rmsle: 0.04654 | valid_mae: 0.20452 | valid_rmse: 0.31063 | valid_mse: 0.09649 |  0:02:02s\n",
-      "epoch 88 | loss: 0.09591 | train_rmsle: 0.04893 | train_mae: 0.20342 | train_rmse: 0.31486 | train_mse: 0.09914 | valid_rmsle: 0.04787 | valid_mae: 0.20101 | valid_rmse: 0.31063 | valid_mse: 0.09649 |  0:02:03s\n",
-      "epoch 89 | loss: 0.09616 | train_rmsle: 0.04726 | train_mae: 0.2021  | train_rmse: 0.3109  | train_mse: 0.09666 | valid_rmsle: 0.04637 | valid_mae: 0.20035 | valid_rmse: 0.30758 | valid_mse: 0.09461 |  0:02:05s\n",
-      "epoch 90 | loss: 0.09552 | train_rmsle: 0.04688 | train_mae: 0.20108 | train_rmse: 0.31004 | train_mse: 0.09612 | valid_rmsle: 0.04626 | valid_mae: 0.19981 | valid_rmse: 0.30742 | valid_mse: 0.09451 |  0:02:06s\n",
-      "epoch 91 | loss: 0.09573 | train_rmsle: 0.04755 | train_mae: 0.20916 | train_rmse: 0.31493 | train_mse: 0.09918 | valid_rmsle: 0.04691 | valid_mae: 0.20723 | valid_rmse: 0.31232 | valid_mse: 0.09754 |  0:02:08s\n",
-      "epoch 92 | loss: 0.09485 | train_rmsle: 0.04686 | train_mae: 0.20371 | train_rmse: 0.31634 | train_mse: 0.10007 | valid_rmsle: 0.04612 | valid_mae: 0.20201 | valid_rmse: 0.31364 | valid_mse: 0.09837 |  0:02:09s\n",
-      "epoch 93 | loss: 0.09578 | train_rmsle: 0.04734 | train_mae: 0.20391 | train_rmse: 0.31296 | train_mse: 0.09794 | valid_rmsle: 0.0466  | valid_mae: 0.20216 | valid_rmse: 0.31012 | valid_mse: 0.09617 |  0:02:10s\n",
-      "epoch 94 | loss: 0.09567 | train_rmsle: 0.04701 | train_mae: 0.20346 | train_rmse: 0.31216 | train_mse: 0.09744 | valid_rmsle: 0.0463  | valid_mae: 0.20177 | valid_rmse: 0.3092  | valid_mse: 0.0956  |  0:02:12s\n",
-      "epoch 95 | loss: 0.09615 | train_rmsle: 0.04657 | train_mae: 0.19859 | train_rmse: 0.31408 | train_mse: 0.09864 | valid_rmsle: 0.04581 | valid_mae: 0.19735 | valid_rmse: 0.31106 | valid_mse: 0.09676 |  0:02:13s\n",
-      "epoch 96 | loss: 0.09594 | train_rmsle: 0.04694 | train_mae: 0.20517 | train_rmse: 0.31133 | train_mse: 0.09692 | valid_rmsle: 0.04651 | valid_mae: 0.20409 | valid_rmse: 0.30935 | valid_mse: 0.0957  |  0:02:14s\n",
-      "epoch 97 | loss: 0.09541 | train_rmsle: 0.04739 | train_mae: 0.20526 | train_rmse: 0.31208 | train_mse: 0.09739 | valid_rmsle: 0.04679 | valid_mae: 0.2037  | valid_rmse: 0.30957 | valid_mse: 0.09583 |  0:02:16s\n",
-      "epoch 98 | loss: 0.09606 | train_rmsle: 0.04706 | train_mae: 0.20423 | train_rmse: 0.31524 | train_mse: 0.09938 | valid_rmsle: 0.04626 | valid_mae: 0.20216 | valid_rmse: 0.3122  | valid_mse: 0.09747 |  0:02:17s\n",
-      "epoch 99 | loss: 0.09641 | train_rmsle: 0.04973 | train_mae: 0.20321 | train_rmse: 0.31253 | train_mse: 0.09767 | valid_rmsle: 0.04895 | valid_mae: 0.2007  | valid_rmse: 0.30926 | valid_mse: 0.09564 |  0:02:18s\n",
-      "Stop training because you reached max_epochs = 100 with best_epoch = 81 and best_valid_mse = 0.09419\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/work/pytorch_tabnet/callbacks.py:172: UserWarning: Best weights from best epoch are automatically used!\n",
-      "  warnings.warn(wrn_msg)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "clf.fit(\n",
     "    X_train=X_train, y_train=y_train,\n",
@@ -575,7 +413,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.13"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION

**What kind of change does this PR introduce?**
This PR solves #122 in a new way.

Embeddings from a same column are automatically grouped together.
Now attention works at the group level and not feature level. So without specifying anything groups for different categorical features are created.

This is a new as it allows users to specify features they would like to be grouped together by the attention mechanism. This can be very useful when sparse features are created (for example after a TD-IDF), attention has a hard time using this kind of features because of sparsity coming from both the data and the attention. Now you can group all those features together and have a single attention.

**Does this PR introduce a breaking change?**
I'm not sure if this should be considered a breaking change or not. I think so as old trained models used with this new code will have a different behaviour.

**What needs to be documented once your changes are merged?**

I think all changes are already documented in this PR.

**Closing issues**
closes #122 
