### PR TITLE
fix: 424 allow any np.intX as training target

### DIFF
--- a/pytorch_tabnet/utils.py
+++ b/pytorch_tabnet/utils.py
@@ -422,8 +422,8 @@ def define_device(device_name):
 
 class ComplexEncoder(json.JSONEncoder):
     def default(self, obj):
-        if isinstance(obj, np.int64):
-            return int(obj)
+        if isinstance(obj, (np.generic, np.ndarray)):
+            return obj.tolist()
         # Let the base class default method raise the TypeError
         return json.JSONEncoder.default(self, obj)
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix to avoid save load errors when targets are np.int8, np.int16, np.int32

**Does this PR introduce a breaking change?**

No this is just a small bugfix

**What needs to be documented once your changes are merged?**

I don't think there is a need for documentation here.

**Closing issues**

closes #424 
